### PR TITLE
fix: add Content-Type: application/json to OpenAI-compatible curl examples

### DIFF
--- a/inference-server/vllm.md
+++ b/inference-server/vllm.md
@@ -61,7 +61,9 @@ python -m vllm.entrypoints.openai.api_server \
 ## Verify tool calling
 
 ```bash
-curl http://localhost:8000/v1/chat/completions -d '{
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
   "model": "muse-glimmer",
   "messages": [{"role":"user","content":"What is the weather in Paris in celsius? Use the tool."}],
   "tools": [{"type":"function","function":{

--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -45,7 +45,9 @@ python -m vllm.entrypoints.openai.api_server \
 Test tool calling against the OpenAI-compatible endpoint:
 
 ```bash
-curl http://localhost:8000/v1/chat/completions -d '{
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
   "model": "muse-glimmer",
   "messages": [{"role": "user", "content": "What is the weather in Paris in celsius? Use the tool."}],
   "tools": [{"type":"function","function":{
@@ -106,7 +108,9 @@ ollama run muse-glimmer
 Ollama exposes an OpenAI-compatible endpoint on `:11434`. Call it from another terminal:
 
 ```bash
-curl http://localhost:11434/v1/chat/completions -d '{
+curl http://localhost:11434/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
   "model": "muse-glimmer",
   "messages": [{"role": "user", "content": "In one sentence, what is Muse Glimmer good at?"}]
 }'


### PR DESCRIPTION
Re-raise of #2, which was approved by @albertodepaola ("Clear fix") but was auto-closed when `main` was force-pushed at 10:54 UTC. `main` has since been restored, and this branch is cleanly mergeable again (1 commit ahead, 0 behind).

**Same branch, same commit (`a93a58f`), byte-identical diff.** Nothing has changed since the approval — only the PR object needed recreating, because GitHub validates reopening against the stale base SHA and refuses.

## Problem

The tool-calling verification `curl` in `inference-server/vllm.md` and `quickstart/README.md` omits `-H "Content-Type: application/json"`.

`curl -d` defaults to `application/x-www-form-urlencoded`. vLLM's OpenAI-compatible server rejects that before it parses the body, so the command fails for every reader, on every model, on every vLLM version:

```
HTTP 400
{"error":{"message":"1 validation error:\n  Unsupported Media Type: Only 'application/json' is allowed","type":"Bad Request","param":null,"code":400}}
```

This is the step the cookbook nominates for confirming a deploy works, so it is the first thing a new reader runs and the first thing that fails.

## Evidence

Reproduced against a live vLLM server (`--enable-auto-tool-choice --tool-call-parser hermes`, served as `muse-glimmer` on `:8000`), running the command **verbatim** out of `inference-server/vllm.md` — extracted with `sed`, md5-verified identical, not retyped:

| Request | Result |
|---|---|
| Command exactly as documented | `HTTP 400` — Unsupported Media Type |
| Identical command + `Content-Type` header | `HTTP 200`, `finish_reason: tool_calls` |

With the header, the response is exactly what `vllm.md` says to expect:

```
tool_calls -> get_weather {"city": "Paris", "units": "celsius"}
```

The only variable between the two runs was the header — not the model, the tool schema, the body, or the server configuration.

## Prior art in this repo

`inference-server/llama-cpp.md` (3 instances) and `inference-server/executorch.md` already pass the header. This brings the vLLM and Ollama examples in line with the convention the repo already follows.

## Scope

Three call sites, documentation only, no behaviour change:

- `inference-server/vllm.md:64`
- `quickstart/README.md:48`
- `quickstart/README.md:109` (Ollama)

**Note on the Ollama hunk:** I verified the two vLLM call sites against a live server. I did **not** test against Ollama, which may be more lenient about the content type. The header is correct either way — happy to drop that hunk if you would rather the change only cover what was verified.
