### PR TITLE
executorch.md: add missing export_dflash command, correct drifted serve guidance

### DIFF
--- a/inference-server/executorch.md
+++ b/inference-server/executorch.md
@@ -7,10 +7,12 @@ Export Muse Glimmer ahead of time and serve it locally on CUDA or Apple silicon,
 
 Unlike the other servers here, ExecuTorch is ahead-of-time: the model is exported once into a `.pte` program for a specific backend, then served from that program.
 
-| Backend | Host | Exported artifacts |
+| Backend | Host | Artifacts written by a local export |
 |---|---|---|
 | CUDA | Linux or Windows | `model.pte` plus `aoti_cuda_blob.ptd` |
 | MLX | macOS on Apple silicon | self-contained `model.pte` |
+
+Prebuilt exports are also published, under [different filenames](#alternative-download-a-prebuilt-export) — exporting a 30B model yourself is optional.
 
 **CPU export is not supported.** For a CPU-only machine, use [`llama-cpp.md`](llama-cpp.md).
 
@@ -67,8 +69,47 @@ Add `--mmproj "$MMPROJ"` to either command for vision; that also writes `pos_emb
 
 A CUDA export autotunes Triton kernels against the GPU it runs on, so export on the same architecture you intend to serve from.
 
-> [!NOTE]
-> Prebuilt `.pte` artifacts are published at [`meta-models/Muse-Glimmer-30B-ExecuTorch-PTE`](https://huggingface.co/meta-models/Muse-Glimmer-30B-ExecuTorch-PTE), covering both quantizations across text / text+image, solo / DFlash, and Metal / CUDA. Downloading one skips this export step — **the runner build in step 3 is still required.** The [announcement above](https://pytorch.org/blog/fast-ondevice-agentic-ai-with-executorch/) prefers downloading over exporting, but the filenames in its example commands are not the ones in the published bundles: each bundle directory names both its `.pte` and its `.ptd` after itself, so `--model-path` and `--data-path` below both need adjusting to match. This page stays on the export path, where the filenames are the ones shown.
+#### Alternative: download a prebuilt export
+
+[`meta-models/Muse-Glimmer-30B-ExecuTorch-PTE`](https://huggingface.co/meta-models/Muse-Glimmer-30B-ExecuTorch-PTE) publishes 16 ready-made exports, which skips step 2 entirely. **Step 3 still applies** — a `.pte` is a model program, not a runtime, so you still build `muse_glimmer_worker` from source.
+
+> [!WARNING]
+> **That repository is 372 GB.** One export is 18–31 GB, so always download a single directory with `--include` rather than the whole repo.
+
+Directories are named `muse-glimmer-<quantization>-128K-<modality>-<decoding>-<backend>`, and all 16 combinations of the four axes exist:
+
+- **Quantization** — `k-quant-17G` targets 24 GB of VRAM, `k-quant-dynamic` targets 32 GB with less degradation (the [model card](https://huggingface.co/meta-models/Muse-Glimmer-30B-ExecuTorch-PTE) quantifies the tradeoff).
+- **Modality** — `text`, or `text-image` for vision.
+- **Decoding** — `solo`, or `dflash` for speculative decoding.
+- **Backend** — `metal` for Apple silicon, `sm80+ptx` for CUDA on SM80 and newer.
+
+Context length is `128K` for every variant. Sizes, by directory:
+
+| Quantization | Modality | Decoding | `…-metal` | `…-sm80+ptx` |
+|---|---|---|---|---|
+| `k-quant-17G` | `text` | `solo` | 17.9 GB | 19.8 GB |
+| `k-quant-17G` | `text` | `dflash` | 19.6 GB | 27.2 GB |
+| `k-quant-17G` | `text-image` | `solo` | 19.4 GB | 21.2 GB |
+| `k-quant-17G` | `text-image` | `dflash` | 21.1 GB | 28.6 GB |
+| `k-quant-dynamic` | `text` | `solo` | 20.7 GB | 22.6 GB |
+| `k-quant-dynamic` | `text` | `dflash` | 22.4 GB | 30.0 GB |
+| `k-quant-dynamic` | `text-image` | `solo` | 22.2 GB | 24.0 GB |
+| `k-quant-dynamic` | `text-image` | `dflash` | 23.8 GB | 31.5 GB |
+
+Each directory holds `<directory-name>.pte`; `sm80+ptx` variants add `<directory-name>.ptd`, and `text-image` variants add `pos_embed.bin`. On CUDA the weights live in the `.ptd` and the `.pte` is only tens of megabytes, so both files are required. The repository root carries the tokenizer metadata — `tokenizer.json`, `tokenizer_config.json` and `chat_template.jinja` — so this one repository covers everything the server needs; the `assets/hf` download in step 1 is for the export path.
+
+```bash
+EXPORT_DIR=muse-glimmer-k-quant-17G-128K-text-solo-sm80+ptx
+
+hf download meta-models/Muse-Glimmer-30B-ExecuTorch-PTE \
+  --include "$EXPORT_DIR/*" tokenizer.json tokenizer_config.json chat_template.jinja \
+  --local-dir exports
+```
+
+Upstream documents the same `--include` approach in [Prebuilt PTE artifacts](https://github.com/pytorch/executorch/blob/main/examples/models/muse-glimmer/README.md#prebuilt-pte-artifacts), though its example still shows the older underscored directory names.
+
+> [!IMPORTANT]
+> A prebuilt directory names its artifacts after itself, so **both** `--model-path` and `--data-path` differ from the export path below — there is no `model.pte` and no `aoti_cuda_blob.ptd` in a download. Upstream's serve snippet and the [announcement](https://pytorch.org/blog/fast-ondevice-agentic-ai-with-executorch/) quickstart both show the export filenames, which fail against downloaded artifacts.
 
 ### 3. Build the runner
 
@@ -93,6 +134,17 @@ python -m executorch.examples.models.muse_glimmer.serving.serve \
 ```
 
 On MLX, drop `--data-path`. For DFlash, replace `exports/solo` with `exports/dflash` in both artifact paths — the server detects the exported method contract. For vision, add `--pos-embed-path <export-dir>/pos_embed.bin`.
+
+From a [prebuilt export](#alternative-download-a-prebuilt-export), substitute the two artifact flags — the rest of the command is unchanged:
+
+```bash
+  --model-path "exports/$EXPORT_DIR/$EXPORT_DIR.pte" \
+  --data-path "exports/$EXPORT_DIR/$EXPORT_DIR.ptd" \
+  --tokenizer-path exports/tokenizer.json \
+  --hf-tokenizer exports \
+```
+
+Drop `--data-path` for a `-metal` variant, since it has no `.ptd`. Add `--pos-embed-path "exports/$EXPORT_DIR/pos_embed.bin"` for a `text-image` variant. A `-dflash` variant needs no extra flag.
 
 ```bash
 curl http://127.0.0.1:8000/v1/chat/completions \
@@ -122,6 +174,7 @@ Muse Glimmer needs `eos_token_id = [<|end_of_text|>, <|eot|>]`. Never stop on `<
 | Worker fails to load the method | Runner built without the quantized / custom-op kernels | Rebuild with the model's CMake workflow preset rather than a plain ExecuTorch build. |
 | Tool calls arrive as plain text | Server started without `--tool-parser atem` | Re-serve with the flag. The default is `none`, which passes model output through unparsed. |
 | `400` on a request that works elsewhere | Unsupported OpenAI parameter | See the rejected parameters above. |
+| Artifact not found on a downloaded export | Export filenames used against a prebuilt directory | A download has no `model.pte` or `aoti_cuda_blob.ptd`; both artifacts are named after their directory. |
 
 ## Next steps
 

--- a/inference-server/executorch.md
+++ b/inference-server/executorch.md
@@ -46,12 +46,27 @@ BACKEND=cuda   # mlx on macOS
 
 ### 2. Export
 
+Target model:
+
 ```bash
 python -m executorch.examples.models.muse_glimmer.export.export_solo \
   --gguf "$TARGET" --backend "$BACKEND" --output-dir exports/solo
 ```
 
-Add `--mmproj "$MMPROJ"` for vision; that also writes `pos_embed.bin` beside `model.pte`. For speculative decoding, `export_dflash` takes `--target-gguf` and `--draft-gguf` instead.
+DFlash speculative decoding lowers the target and the draft together, into their own export directory:
+
+```bash
+python -m executorch.examples.models.muse_glimmer.export.export_dflash \
+  --target-gguf "$TARGET" \
+  --draft-gguf "$DRAFT" \
+  --backend "$BACKEND" \
+  --output-dir exports/dflash
+```
+
+Add `--mmproj "$MMPROJ"` to either command for vision; that also writes `pos_embed.bin` beside `model.pte`.
+
+> [!NOTE]
+> [`meta-models/Muse-Glimmer-30B-ExecuTorch-PTE`](https://huggingface.co/meta-models/Muse-Glimmer-30B-ExecuTorch-PTE) publishes prebuilt `.pte` artifacts covering both quantizations, text and text+image, solo and DFlash, for CUDA and Metal. It skips this export step but not the runner build below, and upstream does not yet document serving those files, so this page stays on the export path.
 
 ### 3. Build the runner
 
@@ -75,7 +90,7 @@ python -m executorch.examples.models.muse_glimmer.serving.serve \
   --host 127.0.0.1 --port 8000
 ```
 
-On MLX, drop `--data-path`. For DFlash, point both artifact paths at `exports/dflash` — the server detects the exported method contract. For vision, add `--pos-embed-path exports/solo/pos_embed.bin`.
+On MLX, drop `--data-path`. For DFlash, replace `exports/solo` with `exports/dflash` in both artifact paths — the server detects the exported method contract. For vision, add `--pos-embed-path <export-dir>/pos_embed.bin`.
 
 ```bash
 curl http://127.0.0.1:8000/v1/chat/completions \
@@ -83,7 +98,7 @@ curl http://127.0.0.1:8000/v1/chat/completions \
   -d '{"model":"muse-glimmer-30B","messages":[{"role":"user","content":"What is the capital of France?"}],"max_tokens":32,"temperature":0}'
 ```
 
-`/health`, `/v1/models` and `/v1/chat/completions` (streaming and non-streaming) are implemented. Set `--max-context` to the context length used at export.
+`/health`, `/v1/models` and `/v1/chat/completions` (streaming and non-streaming) are implemented. `--max-context` bounds the context window; prompts over it are rejected with a 400.
 
 ## Verify tool calling
 

--- a/inference-server/executorch.md
+++ b/inference-server/executorch.md
@@ -66,7 +66,7 @@ python -m executorch.examples.models.muse_glimmer.export.export_dflash \
 Add `--mmproj "$MMPROJ"` to either command for vision; that also writes `pos_embed.bin` beside `model.pte`.
 
 > [!NOTE]
-> [`meta-models/Muse-Glimmer-30B-ExecuTorch-PTE`](https://huggingface.co/meta-models/Muse-Glimmer-30B-ExecuTorch-PTE) publishes prebuilt `.pte` artifacts covering both quantizations, text and text+image, solo and DFlash, for CUDA and Metal. It skips this export step but not the runner build below, and upstream does not yet document serving those files, so this page stays on the export path.
+> Prebuilt `.pte` artifacts are published at [`meta-models/Muse-Glimmer-30B-ExecuTorch-PTE`](https://huggingface.co/meta-models/Muse-Glimmer-30B-ExecuTorch-PTE), covering both quantizations across text / text+image, solo / DFlash, and Metal / CUDA. Downloading one skips this export step — **the runner build in step 3 is still required.** Their CUDA blob is named after its own directory rather than `aoti_cuda_blob.ptd`, so `--data-path` below needs adjusting to match. Upstream does not document serving these files yet, so this page stays on the export path.
 
 ### 3. Build the runner
 

--- a/inference-server/executorch.md
+++ b/inference-server/executorch.md
@@ -3,7 +3,7 @@
 Export Muse Glimmer ahead of time and serve it locally on CUDA or Apple silicon, with vision, tool calling, and DFlash speculative decoding.
 
 > [!NOTE]
-> Status: supported upstream — text, vision, tool calling and DFlash. Not re-run for this cookbook, so no VRAM or throughput numbers are published here. Upstream reference: [`examples/models/muse-glimmer`](https://github.com/pytorch/executorch/tree/main/examples/models/muse-glimmer).
+> Status: supported upstream — text, vision, tool calling and DFlash. Not re-run for this cookbook, so no VRAM or throughput numbers are published here; the upstream announcement, [Fast on-device agentic AI with ExecuTorch](https://pytorch.org/blog/fast-ondevice-agentic-ai-with-executorch/), explains why this model is exported rather than reimplemented per backend, and publishes PyTorch's own measurements on Apple silicon and NVIDIA. Upstream reference: [`examples/models/muse-glimmer`](https://github.com/pytorch/executorch/tree/main/examples/models/muse-glimmer).
 
 Unlike the other servers here, ExecuTorch is ahead-of-time: the model is exported once into a `.pte` program for a specific backend, then served from that program.
 
@@ -65,8 +65,10 @@ python -m executorch.examples.models.muse_glimmer.export.export_dflash \
 
 Add `--mmproj "$MMPROJ"` to either command for vision; that also writes `pos_embed.bin` beside `model.pte`.
 
+A CUDA export autotunes Triton kernels against the GPU it runs on, so export on the same architecture you intend to serve from.
+
 > [!NOTE]
-> Prebuilt `.pte` artifacts are published at [`meta-models/Muse-Glimmer-30B-ExecuTorch-PTE`](https://huggingface.co/meta-models/Muse-Glimmer-30B-ExecuTorch-PTE), covering both quantizations across text / text+image, solo / DFlash, and Metal / CUDA. Downloading one skips this export step — **the runner build in step 3 is still required.** Their CUDA blob is named after its own directory rather than `aoti_cuda_blob.ptd`, so `--data-path` below needs adjusting to match. Upstream does not document serving these files yet, so this page stays on the export path.
+> Prebuilt `.pte` artifacts are published at [`meta-models/Muse-Glimmer-30B-ExecuTorch-PTE`](https://huggingface.co/meta-models/Muse-Glimmer-30B-ExecuTorch-PTE), covering both quantizations across text / text+image, solo / DFlash, and Metal / CUDA. Downloading one skips this export step — **the runner build in step 3 is still required.** The [announcement above](https://pytorch.org/blog/fast-ondevice-agentic-ai-with-executorch/) prefers downloading over exporting, but the filenames in its example commands are not the ones in the published bundles: each bundle directory names both its `.pte` and its `.ptd` after itself, so `--model-path` and `--data-path` below both need adjusting to match. This page stays on the export path, where the filenames are the ones shown.
 
 ### 3. Build the runner
 


### PR DESCRIPTION
## Why

The page told readers to point the serve artifact paths at `exports/dflash`, but never gave the command that creates that directory. The DFlash path dead-ended.

While in the file I re-verified every command, flag, and path against the ground truth.

## Ground truth

Local `pytorch/executorch` checkout, `main` @ `50a37d1adaa8`, canonical doc `examples/models/muse-glimmer/README.md`. Where the README is silent I cite the source it documents.

## Fixes

| # | Change | Confirmed in |
|---|---|---|
| 1 | **Add the full `export_dflash` command** — `--target-gguf`, `--draft-gguf`, `--backend`, `--output-dir`. This is the fix for the reported gap, and it gives the already-declared `$DRAFT` variable a purpose. | `README.md:74-82`; argparse in `export/export_dflash.py:735-769` |
| 2 | Split Export into "Target model" / "DFlash", and move the `--mmproj` note so it applies to both commands | `README.md:61-92`, esp. "Add `--mmproj ...` to either command" at `README.md:84-85` |
| 3 | Serve/DFlash: "replace `exports/solo` with `exports/dflash` in **both** artifact paths" rather than "point both artifact paths at `exports/dflash`" | `README.md:150-152`. The blob keeps the name `aoti_cuda_blob.ptd` inside a DFlash export dir too — `dev/BENCHMARKING.md:228` |
| 4 | Serve/vision: `--pos-embed-path <export-dir>/pos_embed.bin`, was hardcoded to `exports/solo/...`. A DFlash+vision export writes its `pos_embed.bin` under `exports/dflash`, so the old text was wrong for exactly the case fix #1 unblocks. | `README.md:152-153` uses the same placeholder; `export/common.py:163-169` writes `pos_embed.bin` into the export's own `--output-dir` |
| 5 | Drop the unsourced "set `--max-context` to the context length used at export". Replaced with the documented behaviour: it bounds the context window and over-length prompts get a 400. | `serving/serve.py:444-448` |
| 6 | Note the new prebuilt-PTE HF repo, which the cookbook referenced nowhere | See below |

## On the prebuilt PTE repo

[`meta-models/Muse-Glimmer-30B-ExecuTorch-PTE`](https://huggingface.co/meta-models/Muse-Glimmer-30B-ExecuTorch-PTE) is new. Contents confirmed through the HF API file listing (39 files): 16 prebuilt artifact sets, the cross product of `{k-quant-17G, k-quant-dynamic}` x `{text, text-image}` x `{solo, dflash}` x `{metal, sm80+ptx}`, plus `tokenizer.json`, `tokenizer_config.json`, and `chat_template.jinja`.

This PR adds a pointer only, no serve invocation, on purpose:

- It skips **export**, not the **runner build**. `muse_glimmer_worker` still only comes from the CMake workflow preset, which is the heavier half of the setup.
- The artifact filenames differ from the exported ones — the prebuilt CUDA blob is `<dirname>.ptd`, not `aoti_cuda_blob.ptd`.
- The ground-truth README does not mention this repo at all, so any serve command against those files would be unsourced. Documenting that flow should follow upstream, as its own change.

## Verified unchanged

`export_solo` (`README.md:67-72`) · `muse-glimmer-cuda` / `muse-glimmer-mlx` workflow presets (`CMakePresets.json`, `workflowPresets`) · every serve flag used (`serving/serve.py:420-520`) · `--tool-parser` choices `atem|none`, default `none`, so the troubleshooting row is right (`serve.py:470-474`) · CUDA `--data-path exports/solo/aoti_cuda_blob.ptd` (`README.md:140`) · `model.pte` output name (`export/common.py:152`).

## Notes

- Status stays **supported upstream**, not "verified". Nothing here was re-run for the cookbook, so no VRAM or throughput numbers are published.
- Shared section order preserved: Install / Serve / Verify tool calling / Stop tokens / Troubleshooting / Next steps.
- Docs-only change.


---

## Follow-up commit: cite the upstream announcement (`31fdba6`)

Adds https://pytorch.org/blog/fast-ondevice-agentic-ai-with-executorch/ to the page.

**Placement: the status callout at the top.** That callout is where the page asserts "supported upstream," and the post is the announcement that makes that true. It is also the only source that answers a question the page never addressed — *why export this model at all* — its argument being that reimplementing novel architectures, multimodal I/O and DFlash across per-backend runtimes does not scale, so you author in PyTorch and let the export handle Triton-on-CUDA and MLX/Metal lowering. A reader who has landed on an ahead-of-time page and is wondering why it is not just llama.cpp gets their answer in the first callout. Install and Next steps were both considered and rejected: the post is framing, not a setup step, and burying framing at the bottom is where it stops being read.

**No figures from the post are reproduced.** The callout points at them as PyTorch's own measurements on Apple silicon and NVIDIA. This page continues to publish none of its own.

### Contradiction found, and it cuts both ways

The prebuilt-PTE note added earlier in this PR said *"upstream does not document serving these files yet."* As of this post that is no longer true — it documents downloading them and calls it the **preferred** path over exporting. That sentence is now corrected.

But the post's own example commands are `--model-path artifacts/dflash-vision/model.pte` and `--data-path artifacts/dflash-vision/aoti_cuda_blob.ptd`, and **the published bundles contain neither filename.** Re-confirmed against the HF API listing: every directory in `Muse-Glimmer-30B-ExecuTorch-PTE` names both its `.pte` and its `.ptd` after itself, e.g. `muse-glimmer-k-quant-17G-128K-text-image-dflash-sm80+ptx/muse-glimmer-k-quant-17G-128K-text-image-dflash-sm80+ptx.{pte,ptd}`. So the post's quickstart, copied literally against a downloaded bundle, does not resolve.

That is a discrepancy in the post, not in this page. It also sharpens the existing caveat: `--model-path` needs adjusting too, not only `--data-path` as the note previously said. The note now records both, and the page still walks the export path, where the filenames shown are the real ones.

### One other addition

Export step now states that a CUDA export autotunes Triton kernels against the detected device, so you should export on the architecture you will serve from. The post says this; the ground-truth checkout corroborates it (`backends/cuda/cuda_backend.py` reads the compute capability and sets `max_autotune` with Triton GEMM/conv backends). It also explains why the prebuilt CUDA bundles are tagged `sm80+ptx`.

### Deliberately not changed

- **Status stays "supported upstream."** The post is an announcement, not a run of this cookbook's commands, and it publishes no numbers we produced. Nothing here was re-verified locally.
- Section order unchanged.
- The post's other material — 128K context with 39 of 52 layers sliding-window, per-session state rebinding behind `--max-sessions` (defaults to `1`, so multi-conversation serving needs it raised), no continuous batching or cross-session prefix sharing yet, no video input — is real and sourced, but it is a scope expansion rather than a link. Flagged separately rather than smuggled in here.
