### PR TITLE
llama.cpp: build from upstream, drop private fork reference

### DIFF
--- a/inference-server/llama-cpp.md
+++ b/inference-server/llama-cpp.md
@@ -3,9 +3,9 @@
 Portable inference across CPU, Metal, CUDA, ROCm and Vulkan — the practical way to run Muse Glimmer on a single machine.
 
 > [!NOTE]
-> Status: verified on Apple silicon (Metal) — text, vision and tool calling, against ready-to-serve GGUF checkpoints. There is no conversion or quantization step.
+> Status: verified on Apple silicon (Metal) against upstream llama.cpp at commit `dd1ea52` — text, vision and tool calling, against ready-to-serve GGUF checkpoints. There is no conversion or quantization step.
 
-Muse Glimmer needs the Muse Glimmer build of llama.cpp, not upstream. It adds the `muse-glimmer` architecture, the vision projector, and DFlash speculative decoding.
+Upstream llama.cpp supports Muse Glimmer. Commit [`62bf73d25`](https://github.com/ggml-org/llama.cpp/commit/62bf73d25) ("model: Muse Glimmer Support", PR #26841) adds the `muse-glimmer` architecture, the vision projector, the ATEM tool-call parser and DFlash speculative decoding. No fork is needed.
 
 ## Install
 
@@ -32,13 +32,12 @@ Full-precision weights are not published as GGUF. For bf16, use the safetensors 
 ### 2. Build
 
 ```bash
-hf download someorgtoo/llama.cpp_onyx --repo-type model --revision muse-glimmer \
-  --local-dir ./llama.cpp_muse-glimmer
-cd llama.cpp_muse-glimmer
+git clone https://github.com/ggml-org/llama.cpp
+cd llama.cpp
 ```
 
 > [!IMPORTANT]
-> `--revision muse-glimmer` is not optional. The repository's `main` branch predates the architecture rename and fails to load these checkpoints with `missing tensor 'blk.0.attn_output_gate.weight'`.
+> Build from `master`. Muse Glimmer support landed on 2026-08-10 and is not in any tagged release yet — the newest tag at the time of writing, `b10343`, is six commits behind `62bf73d25` and does not register the `muse-glimmer` architecture, so the prebuilt release binaries cannot load these checkpoints.
 
 Pick your backend:
 
@@ -67,7 +66,7 @@ cmake --build build -j"$(nproc)"             --target llama-server llama-cli lla
 
 If `ccache` errors during the build, add `-DGGML_CCACHE=OFF`.
 
-Run the commands below from `llama.cpp_muse-glimmer`, so `./build/bin/` and the `./muse-glimmer/` download directory resolve.
+Run the commands below from the `llama.cpp` clone, with the `muse-glimmer/` download directory inside it, so both `./build/bin/` and `./muse-glimmer/` resolve. Otherwise pass absolute paths to `-m` and `--mmproj`.
 
 ## Serve
 
@@ -92,8 +91,9 @@ srv load_model: initializing, n_slots = 1, n_ctx_slot = 131072, kv_unified = 'fa
 
 If it instead reports `exceeds the training context ... - capping`, the GGUF's
 `context_length` metadata is stale and the server clamps the slot to it — no serve
-flag overrides this. Fix the metadata:
-`gguf_set_metadata.py <model>.gguf muse-glimmer.context_length 131072`.
+flag overrides this. Fix the metadata with the script in the llama.cpp clone
+(`muse-glimmer` is the architecture name llama.cpp registers, so it is the key prefix):
+`python gguf-py/gguf/scripts/gguf_set_metadata.py <model>.gguf muse-glimmer.context_length 131072`.
 
 | Flag | Why |
 |---|---|
@@ -107,7 +107,7 @@ flag overrides this. Fix the metadata:
 Drop `--mmproj` for text-only. For speculative decoding add `-md <draft>.gguf --spec-type draft-dflash -ngld 99 --spec-draft-n-max 4`.
 
 > [!NOTE]
-> The `muse-glimmer` branch ships no chat template under `models/templates/`, so there is nothing to pass to `--chat-template-file`. `--jinja` on its own uses the template embedded in the GGUF, which is what these commands rely on.
+> Do not pass `--chat-template-file`. Upstream ships no Muse Glimmer template under `models/templates/`, and none is needed: `--jinja` uses the template embedded in the GGUF, which is byte-for-byte identical to the `chat_template.jinja` published with the safetensors checkpoint. llama.cpp selects the ATEM tool-call parser by detecting that template, so tool calling works from `--jinja` alone.
 
 Smoke test (`--noproxy` bypasses a proxy that would intercept loopback):
 
@@ -131,7 +131,7 @@ Set it server-wide with `--chat-template-kwargs`, or per request:
 {"model":"muse-glimmer","messages":[...],"chat_template_kwargs":{"reasoning_strength":"low"}}
 ```
 
-Completion tokens on one agentic decision, same prompt, `temperature=0`:
+The model card documents four levels: `low`, `medium`, `high`, `xhigh`. Completion tokens on one agentic decision, same prompt, `temperature=0`:
 
 | `reasoning_strength` | completion tokens |
 |---|---|
@@ -178,7 +178,7 @@ Returns `finish_reason: "tool_calls"` and a `tool_calls` array with `get_weather
 
 ## Stop tokens
 
-Muse Glimmer needs `eos_token_id = [<|end_of_text|>, <|eot|>]`. Never stop on `<|eom|>`. The template handles this; `--jinja --chat-template-file` is what wires it up. See [`README.md`](README.md#get-stop-tokens-right).
+Muse Glimmer needs `eos_token_id = [<|end_of_text|>, <|eot|>]`. Never stop on `<|eom|>`. The template handles this; `--jinja` is what wires it up. See [`README.md`](README.md#get-stop-tokens-right).
 
 ## Next steps
 


### PR DESCRIPTION
Fixes the three review findings on `inference-server/llama-cpp.md`. Everything below was re-verified end to end on Apple silicon (M-series, Metal) against **upstream** `ggml-org/llama.cpp` at `dd1ea52`, with the public GGUFs freshly downloaded from `meta-models/Muse-Glimmer-30B-GGUF`.

## Finding 1 — still references the private `someorgtoo` repository

**Upstream now supports Muse Glimmer, so the fork is gone from the page entirely.**

`ggml-org/llama.cpp` commit [`62bf73d25`](https://github.com/ggml-org/llama.cpp/commit/62bf73d25) — "model: Muse Glimmer Support" (PR #26841, 2026-08-10T11:07Z) — adds:

- `src/llama-arch.cpp:74` → `{ LLM_ARCH_MUSE_GLIMMER, "muse-glimmer" }`
- `src/models/muse-glimmer.cpp`, `tools/mtmd/models/muse-glimmer.cpp` (vision)
- `common/chat.cpp:3096` `common_chat_params_init_muse_glimmer` — **the ATEM tool-call parser**, auto-selected at `common/chat.cpp:3263` when the template contains both `<atem:function_calls>` and `<|eom|>`

That last point is the one that mattered: the ATEM parser was the reason the fork existed, and it is upstream now.

`hf download someorgtoo/llama.cpp_onyx --revision muse-glimmer` is replaced with `git clone https://github.com/ggml-org/llama.cpp`. This also removes the last leak of the old `onyx` codename — it was the only occurrence left in the repo (grepped for `someorgtoo` / `onyx` across all `.md` and `.py`; no other page needed touching).

**One caveat I added to the page, because it is a real trap:** the support is on `master` but **not in any tagged release yet**. Newest tag `b10343` = commit `e23e9440`, which is 6 commits *behind* `62bf73d25` and does not register the architecture. So prebuilt release binaries cannot load these checkpoints. The page now says build from `master` and explains why.

I dropped the old `missing tensor 'blk.0.attn_output_gate.weight'` error string rather than reattributing it. That error came from the *fork's* `main` branch; I did not build a pre-`62bf73d25` upstream to confirm what upstream prints, so publishing it as an upstream symptom would have been a guess.

## Finding 2 — broken model paths

**Not broken — all four filenames confirmed correct, at repo root, with sizes matching the table.** Verified against the HF API file listing for the now-public `meta-models/Muse-Glimmer-30B-GGUF`:

| File on the page | Exists | Actual size | Page says |
|---|---|---|---|
| `muse-glimmer-30B-kquant-17gb.gguf` | yes | 16.76 GB | ~17 GB |
| `muse-glimmer-30B-kquant-dynamic.gguf` | yes | 19.65 GB | ~20 GB |
| `mmproj-kquant.gguf` | yes | 1.40 GB | ~1.4 GB |
| `dflash-kquant.gguf` | yes | 1.63 GB | ~1.6 GB |

No path changes needed. I did clarify the working-directory note: the old text said to run from `llama.cpp_muse-glimmer` so `./muse-glimmer/` resolves, which only worked if the download landed inside the clone. It now says so explicitly and offers absolute paths as the alternative.

## Finding 3 — conflicting chat-template guidance

**Resolved in favour of bare `--jinja`, and the contradiction is removed.**

- Upstream `models/templates/` has 66 files and **none** for Muse Glimmer — nothing exists to pass to `--chat-template-file`.
- The GGUF-embedded chat template is **byte-for-byte identical** (7167 chars, both) to `chat_template.jinja` in `meta-models/Muse-Glimmer-30B`. So the safetensors template the review flagged is not a second, competing source — it is the same template. Nothing to reconcile.
- It contains `<atem:function_calls>` and `<|eom|>`, which is exactly what triggers upstream's ATEM parser selection. `--jinja` alone is sufficient and correct.

The Serve note now says plainly "Do not pass `--chat-template-file`", and the **Stop tokens** section, which still said `--jinja --chat-template-file` is what wires up the stop tokens, now says `--jinja`.

## Also verified while in there

- **`gguf_set_metadata.py` key prefix** — correct. Arch string llama.cpp registers is `muse-glimmer`, so `muse-glimmer.context_length` is right. The script's argparse is `(model, key, value)`, matching the page's usage. But bare `gguf_set_metadata.py` is not on `$PATH`; it lives at `gguf-py/gguf/scripts/gguf_set_metadata.py` (console script `gguf-set-metadata`, with dashes). Page now gives a runnable path.
- **Stop tokens** — correct. `generation_config.json` has `eos_token_id: [200001, 200008]`; `tokenizer.json` maps those to `<|end_of_text|>` and `<|eot|>`. `<|eom|>` is 200007 and is *not* an eos. The "never stop on `<|eom|>`" guidance stands.
- **Every serve flag exists upstream**: `--jinja`, `--mmproj`, `--reasoning-format`, `--chat-template-kwargs`, `-md`, `-ngld`, `--spec-draft-n-max`, and `--spec-type` with `draft-dflash` as a valid value (`common/speculative.cpp:36`). CMake `LLAMA_BUILD_UI` / `LLAMA_USE_PREBUILT_UI` (`CMakeLists.txt:120-121`) and `GGML_CCACHE` (`ggml/CMakeLists.txt:125`) all exist.
- **Actually ran it**, not just grepped:
  - Built with the page's exact Metal command; `llama-server`, `llama-cli`, `llama-mtmd-cli` all link.
  - Serve command loads: `n_slots = 1, n_ctx_slot = 131072, kv_unified = 'false'` — matches the quoted log line verbatim, so the 131072 claim holds.
  - Smoke test returns 391, with thinking correctly split into `reasoning_content` (so `--reasoning-format deepseek` works).
  - Tool calling returns `finish_reason: "tool_calls"` and `get_weather(city="Paris", units="celsius")` — the exact result the page promises.
  - Vision: base64 PNG in, correct answer out.
  - DFlash: `adding speculative implementation 'draft-dflash'`, `n_max=4`, and a real generation at **40.6% draft acceptance** (169/416).
  - `/health` answers without the API key, confirming the `--api-key` row.

## What I could NOT verify

- **The `reasoning_strength` token counts (1,811 / 752 / 256).** I left them untouched. They are not reproducible from the page as written because the prompt is only described as "one agentic decision" and is not recorded. On my own trivial tool-call prompt the spread collapses (high 105, medium 109, low 85, xhigh 105), which neither confirms nor contradicts the table — it just is not the same prompt. Someone with the original prompt should either record it on the page or re-measure. Flagging rather than silently replacing measured data with my own non-comparable numbers.
- **`xhigh` stays "Not measured yet"** for the same reason. I did confirm `xhigh` is a real level — the model card documents `low / medium / high / xhigh` — and added that list to the page, since previously a reader had no way to know `xhigh` was even valid.
- **Non-Metal backends.** The CUDA and CPU cmake lines are unchanged and were not built or run here; they were not in scope and I have no NVIDIA hardware on this box.

## Status banner

Kept as verified — the findings support it rather than contradict it. I narrowed it to name the commit it was verified against (`dd1ea52`), since "verified" against a moving `master` is not meaningful without one.

---

**Note on branching:** the task said to branch off local `main` (`0d794f2`), but that commit shares **no common ancestor** with `origin/main` (`d2365cb`) — the local checkout has an unrelated history, so a PR from it was rejected outright. This PR is therefore based on `origin/main`. The page content for `llama-cpp.md` is byte-identical between the two, so the change applies unchanged; only the base differs.
