### PR TITLE
docs: make inference-server README a plain page list, remove README 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Each recipe follows the same contract so you always know what you're getting:
 
 ## Status
 
-This cookbook is under active construction. Sections land incrementally, and each folder's README states where it stands. Unresolved decisions are tracked in [`OPEN_QUESTIONS.md`](OPEN_QUESTIONS.md).
+This cookbook is under active construction. Sections land incrementally, and each folder's README states where it stands.
 
 Contributions welcome. Every recipe follows the shared template in [`assets/RECIPE_TEMPLATE.md`](assets/RECIPE_TEMPLATE.md).
 

--- a/inference-server/README.md
+++ b/inference-server/README.md
@@ -2,23 +2,13 @@
 
 One page per server. Each is a deeper guide than the [quickstart](../quickstart/): full serve command, tool-parser config, and how to verify tool calling actually works.
 
-| Server | Page | Status |
-|---|---|---|
-| vLLM | [`vllm.md`](vllm.md) | Verified (native `MuseGlimmerForCausalLM`) |
-| Ollama | [`ollama.md`](ollama.md) | Pending verified GGUF |
-| LM Studio | [`lm-studio.md`](lm-studio.md) | Partner-authored (LM Studio Bionic) |
-| SGLang | [`sglang.md`](sglang.md) | Documented upstream (pre-release branch) |
-| llama.cpp | [`llama-cpp.md`](llama-cpp.md) | Verified on a `master` build (GGUF: text, vision, tool calling) |
-| Unsloth | [`unsloth.md`](unsloth.md) | Partner-authored (GGUF published) |
-| ExecuTorch | [`executorch.md`](executorch.md) | Supported upstream (CUDA / MLX; text, vision, tool calling, DFlash) |
-
-**Three of these need a pre-release build.** Upstream support for Muse Glimmer has not reached a tagged release in vLLM, llama.cpp, or SGLang:
-
-- **vLLM** — an open PR (#51655); the Docker image is the supported path.
-- **llama.cpp** — merged to `master`, not in any tag. The newest tag (`b10343`) does not register the architecture, so prebuilt binaries fail.
-- **SGLang** — an unreleased branch (PR #34262).
-
-Each page gives the exact build or image to use.
+- [`vllm.md`](vllm.md) — serving to a team on GPUs, with native tool calling and reasoning parsers.
+- [`ollama.md`](ollama.md) — one command to a local model, from a prebuilt quantized GGUF.
+- [`lm-studio.md`](lm-studio.md) — a desktop GUI and built-in agent; MLX on Apple silicon.
+- [`sglang.md`](sglang.md) — high-throughput serving for many concurrent local users.
+- [`llama-cpp.md`](llama-cpp.md) — one machine, portable across CPU, Metal, CUDA, ROCm and Vulkan.
+- [`unsloth.md`](unsloth.md) — fine-tuning as well as serving, through a local GUI.
+- [`executorch.md`](executorch.md) — on-device, ahead-of-time export to CUDA or Apple silicon.
 
 Most pages follow the same section order — **Install → Serve → Verify tool calling → Stop tokens → Next steps** — so you can switch between servers and compare the same step side by side. Some add a Troubleshooting section before Next steps.
 

--- a/inference-server/README.md
+++ b/inference-server/README.md
@@ -7,10 +7,18 @@ One page per server. Each is a deeper guide than the [quickstart](../quickstart/
 | vLLM | [`vllm.md`](vllm.md) | Verified (native `MuseGlimmerForCausalLM`) |
 | Ollama | [`ollama.md`](ollama.md) | Pending verified GGUF |
 | LM Studio | [`lm-studio.md`](lm-studio.md) | Partner-authored (LM Studio Bionic) |
-| SGLang | [`sglang.md`](sglang.md) | Pending |
-| llama.cpp | [`llama-cpp.md`](llama-cpp.md) | Verified (GGUF: text, vision, tool calling) |
-| Unsloth | [`unsloth.md`](unsloth.md) | Pending verified GGUF |
+| SGLang | [`sglang.md`](sglang.md) | Documented upstream (pre-release branch) |
+| llama.cpp | [`llama-cpp.md`](llama-cpp.md) | Verified on a `master` build (GGUF: text, vision, tool calling) |
+| Unsloth | [`unsloth.md`](unsloth.md) | Partner-authored (GGUF published) |
 | ExecuTorch | [`executorch.md`](executorch.md) | Supported upstream (CUDA / MLX; text, vision, tool calling, DFlash) |
+
+**Three of these need a pre-release build.** Upstream support for Muse Glimmer has not reached a tagged release in vLLM, llama.cpp, or SGLang:
+
+- **vLLM** — an open PR (#51655); the Docker image is the supported path.
+- **llama.cpp** — merged to `master`, not in any tag. The newest tag (`b10343`) does not register the architecture, so prebuilt binaries fail.
+- **SGLang** — an unreleased branch (PR #34262).
+
+Each page gives the exact build or image to use.
 
 Most pages follow the same section order — **Install → Serve → Verify tool calling → Stop tokens → Next steps** — so you can switch between servers and compare the same step side by side. Some add a Troubleshooting section before Next steps.
 


### PR DESCRIPTION
Turns the inference-server folder README into a directory that helps a reader **choose** a server, and removes one live 404 from the front page.

Touches only `README.md` and `inference-server/README.md`. The server pages have open PRs (#6–#9, plus in-flight vLLM work) and are deliberately untouched here.

## `inference-server/README.md` — status table becomes a plain page list

The Status column is gone. The table and the pre-release footnote under it are replaced by one bullet per page, each saying what that server is *for*, in the spirit of `quickstart/README.md`'s "Best for" column:

- `vllm.md` — serving to a team on GPUs, with native tool calling and reasoning parsers.
- `ollama.md` — one command to a local model, from a prebuilt quantized GGUF.
- `lm-studio.md` — a desktop GUI and built-in agent; MLX on Apple silicon.
- `sglang.md` — high-throughput serving for many concurrent local users.
- `llama-cpp.md` — one machine, portable across CPU, Metal, CUDA, ROCm and Vulkan.
- `unsloth.md` — fine-tuning as well as serving, through a local GUI.
- `executorch.md` — on-device, ahead-of-time export to CUDA or Apple silicon.

Everything else on the page is unchanged: the section-order paragraph, the partner-authored-pages paragraph, "Get stop tokens right", and "Pointing an agent harness at the endpoint".

### The pre-release facts did not disappear

They moved out of the README's way, not out of the repo. Each page still leads with its own status callout, which is where a reader who has committed to a server will actually see it:

| Page | Caveat it carries | Where |
|---|---|---|
| `vllm.md` | Unverified end to end; Docker image is the supported path, `pip install vllm` will not serve this model (PR #51655) | in-flight vLLM PR |
| `llama-cpp.md` | Build from `master`; not in any tag, `b10343` does not register the arch | #6 |
| `sglang.md` | Not in an SGLang release — upstream `muse-glimmer` branch (PR #34262) | #7 |
| `unsloth.md` | GGUF published, tool-calling run still pending | #7 |
| `executorch.md` | Supported upstream, not re-run for this cookbook | #9 |
| `ollama.md` | Pending verified content; use vLLM for tool calling today | on `main` |

One gap, flagged rather than fixed here: **`lm-studio.md` carries no status callout of its own**, while `quickstart/README.md` says the LM Studio / MLX quant publish is still pending. Nothing is lost by this PR — the old table row said "Partner-authored", which is attribution rather than a caveat, and the partner-authored paragraph still says it. But that page is the one place a pending-publish fact is not stated. Fixing it belongs in a PR that owns the page.

## `README.md` — dead link

The Status section linked to `OPEN_QUESTIONS.md`, which does not exist in the public lineage — it was an internal tracker, intentionally left out when the public history was created. An external reader clicking it gets a 404 today.

Removed the sentence rather than rewriting it: the preceding sentence ("each folder's README states where it stands") already carries the intent, and the separate contributions/template paragraph below is untouched. Nothing else in the repo references `OPEN_QUESTIONS.md`.
