### PR TITLE
intel: link Intel's day-0 Muse Glimmer guide; fill blank Xeon memory cell

### DIFF
--- a/platform/intel.md
+++ b/platform/intel.md
@@ -16,7 +16,7 @@ Intel has a broad AI portfolio, from consumer laptops powered by Intel® Core™
 |---|---|---|---|---|
 | Arc Pro GPU (server) | server | Arc Pro B70 x 2 | 32 GB LPDDR5 per accelerator | bf16 |
 | Arc Pro GPU (consumer) | consumer | Arc Pro B Series | 32 GB GDDR6 | bf16, int4 |
-| Xeon 6 6980P | server | N/A |  | bf16 |
+| Xeon 6 6980P | server | N/A | depends on DDR5 mounted, suggest to > 512 GB | bf16 |
 | Intel Core Ultra Series 2 and 3 | consumer | iGPU | 32GB+ | q4_k_m, int4 |
 
 <!-- Class is one of: `consumer`, `workstation`, `server`, `edge`, `cloud-instance`.
@@ -84,6 +84,8 @@ python -m vllm.entrypoints.openai.api_server \
 ```
 
 Tensor parallelism across >= 2 accelerators (e.g. `--tensor-parallel-size 4`) also works.
+
+Intel's own day-0 instructions for this path — including the tool-calling flags and a Hugging Face Transformers alternative — are in [Day-0 Muse Glimmer Support on Intel Platforms with vLLM and Hugging Face](https://huggingface.co/blog/MatrixYao/muse-glimmer-day0), which Intel reports validating on Arc Pro B70 and Arc Pro B60.
 
 **Supported precisions**
 
@@ -286,6 +288,8 @@ vllm serve muse-glimmer-bf16 \
 ```
 
 Confirm the deploy with the tool-calling check in [`../inference-server/vllm.md`](../inference-server/vllm.md) — Muse Glimmer is an agentic model, so "it generates text" isn't a working deploy.
+
+Intel's own day-0 instructions for this path are in [Day-0 Muse Glimmer Support on Intel Platforms with vLLM and Hugging Face](https://huggingface.co/blog/MatrixYao/muse-glimmer-day0), which Intel reports validating on Xeon 6. It also covers the Hugging Face Transformers route on Xeon, including DFlash speculative decoding against `meta-models/Muse-Glimmer-30B-assistant`.
 
 > [!WARNING]
 > Stop tokens: `eos_token_id = [<\|end_of_text\|>, <\|eot\|>]`. Never stop on `<\|eom\|>` — it marks end-of-*message*, the turn continues, and stopping there reduces parallel tool calling to near zero. Confirm your runtime doesn't override this. Details: [`../inference-server/README.md`](../inference-server/README.md).


### PR DESCRIPTION
## What I found

Intel published **exactly one** day-0 piece for Muse Glimmer:

- **[Day-0 Muse Glimmer Support on Intel Platforms with vLLM and Hugging Face](https://huggingface.co/blog/MatrixYao/muse-glimmer-day0)** — Intel, published 2026-08-10. Authors include **Liangliang Ma** and **Jiang Li**, who are the same engineers credited as "Verified by" in this page's Arc Pro (server) and Xeon 6 snapshots.

Supporting context (found, but not used to change any spec on the page):

- [Run Gemma 4 on Intel® Arc™ GPUs Out-Of-the-Box](https://huggingface.co/blog/MatrixYao/intel-gpu) — Intel, 2026-04-01. Same team, previous model, no Muse Glimmer content.
- [Meta's launch blog](https://research.meta.ai/blog/introducing-muse-glimmer-open-agentic-model) names Intel as a launch partner but links no Intel material.

**Nothing else exists that I could find.** I checked: Intel's other Muse Glimmer authors on Hugging Face (`LiangliangMa`, `bigPYJ`, `YangKai0616`, `xuechendi`, `jianan-gu`, `sywangyi`) — all point back to the same single post; the `meta-models/Muse-Glimmer-30B` model card, which links no partner material; and web search for Intel newsroom / developer-blog / OpenVINO / `ipex-llm` coverage, which turned up nothing on Muse Glimmer. `intel.com` itself is bot-blocked (HTTP 403 via Akamai) from this environment, including the official Arc Pro B70 SKU specification page — see the open items below.

I deliberately did **not** add generic Intel marketing links to bulk this out.

## What changed

Two things only.

**1. Linked Intel's day-0 guide from the two blocks it actually covers** — Arc Pro GPU (server) and Xeon 6 6980P. Intel's post documents the vLLM XPU and vLLM CPU paths, the tool-calling flags, the Hugging Face Transformers alternative, and (on Xeon) DFlash speculative decoding against `meta-models/Muse-Glimmer-30B-assistant`. Validation claims are attributed to Intel, not to us, and no performance figures were copied.

Not added to Arc Pro (consumer) or Core Ultra: Intel's post covers neither llama.cpp nor Core Ultra, so a link there would be decorative.

**2. Filled the empty Memory cell for Xeon 6 6980P** in the Platforms table, so it stops rendering blank in the generated index on `platform/README.md`. The value is copied verbatim from that platform's own Snapshot on this page (`depends on DDR5 mounted, suggest to > 512 GB`) — this is not a new spec claim, it is the page's existing statement propagated into the cell the index reads from.

Verified with `python platform/validate.py --index` — the Xeon row now populates.

## Contradictions: 1 of 4 resolved, 3 still need Intel

Resolved:

- ✅ **Xeon 6 6980P empty memory cell** — filled from the page's own Snapshot, as above.

Still open. Intel's published material does not settle any of these, so I left them exactly as they are rather than guess:

- ❌ **Arc Pro (server) memory type** — Platforms table says `32 GB LPDDR5 per accelerator`; the Snapshot says `32 GB GDDR6 per card`. Intel's day-0 post never states a memory type, and Intel's official Arc Pro B70 specification page is unreachable from here (403). Third-party reviews say GDDR6 and the page itself says GDDR6 in two other places, so LPDDR5 looks like the typo — but that is inference, not an Intel source, and this is a public partner page. **Needs Intel to confirm.**
- ❌ **Arc Pro (consumer) precisions** — Platforms table claims `bf16, int4` verified; the Supported precisions block lists only `q4_k_m`. The two do not overlap. Intel published nothing on the consumer llama.cpp path. **Needs Intel to confirm.**
- ❌ **Core Ultra precisions** — Platforms table says `q4_k_m, int4`, the block lists only `q4_k_m`, and the Performance row says `bf16`. Three different answers. Intel's post does not cover Core Ultra at all. **Needs Intel to confirm.**

## Coordination with PR #5

PR #5 (`fix/intel-serve-commands`) owns this same file and is still open. This PR is branched separately off `origin/main` and **does not touch either code fence that #5 edits** — the parser names, the model path and the `-tp` line are entirely #5's.

Two of my three hunks are *adjacent* to #5's hunks, so **merge order matters**:

- My Arc Pro (server) hunk inserts at line ~86, just past the end of #5's first hunk.
- My Xeon hunk inserts at line ~290, just past the end of #5's second hunk.

These should merge cleanly in either order, but whoever merges second should re-run `python platform/validate.py intel.md` to confirm. If there is a conflict, #5's version of the command blocks wins — my changes are only the prose lines and the table cell.

## Validation

```
$ python platform/validate.py intel.md
Checked 1 page(s) [intel.md]: 0 error(s), 0 warning(s).
```
