### PR TITLE
fix: Intel deploy commands — unrunnable -tp placeholder, model path, parser names (recreates #5)

### DIFF
--- a/platform/intel.md
+++ b/platform/intel.md
@@ -78,7 +78,7 @@ hf download meta-models/Muse-Glimmer-30B --local-dir ./muse-glimmer-bf16
 ZE_AFFINITY_MASK=0,1  \
 python -m vllm.entrypoints.openai.api_server \
   --model ./muse-glimmer-bf16 \
-  --reasoning-parser muse-glimmer \
+  --reasoning-parser muse_glimmer \
   --enforce-eager \
   --tensor-parallel-size 2
 ```
@@ -276,12 +276,12 @@ hf download meta-models/Muse-Glimmer-30B --local-dir ./muse-glimmer-bf16
 ```
 
 ```bash
-vllm serve muse-glimmer-bf16 \
-    -tp $<TP_SIZE> \
+vllm serve ./muse-glimmer-bf16 \
+    -tp <TP_SIZE> \
     --dtype=bfloat16 \
     --trust-remote-code --enable-auto-tool-choice \
-    --tool-call-parser muse-glimmer \
-    --reasoning-parser muse-glimmer \
+    --tool-call-parser muse_glimmer \
+    --reasoning-parser muse_glimmer \
     --generation-config auto
 ```
 

--- a/platform/intel.md
+++ b/platform/intel.md
@@ -277,7 +277,7 @@ hf download meta-models/Muse-Glimmer-30B --local-dir ./muse-glimmer-bf16
 
 ```bash
 vllm serve ./muse-glimmer-bf16 \
-    -tp <TP_SIZE> \
+    -tp "<TP_SIZE>" \
     --dtype=bfloat16 \
     --trust-remote-code --enable-auto-tool-choice \
     --tool-call-parser muse_glimmer \


### PR DESCRIPTION
> **Original author: Prashant Bhende (@p-bhende).** This is his work — the branch `fix/intel-serve-commands` and both of its commits are authored by him and are unchanged. I am only reopening it as a new PR object because the original was auto-closed; nothing about the branch has been touched.

Recreates #5, which GitHub auto-closed during a history-rewrite attempt that was rolled back. Branch and commits are unchanged; the original review thread is still readable at #5.

The old PR object cannot be reopened — GitHub has latched it (`422 branch has no history in common with main`), and reopening was already exhausted via GraphQL, REST, and ref-update events. Head is still `aeb0407`, identical to what #5 pointed at.

---

## Review status carried over from #5

**The `-tp` blocker is RESOLVED.** Head commit `aeb0407` changed `-tp $<TP_SIZE>` → `-tp "<TP_SIZE>"`. This was verified by *execution*, with a stub `vllm` on PATH:

- old form: exited 1 with `TP_SIZE: No such file or directory` — bash treated `<TP_SIZE` as an input redirect and never reached `vllm` at all.
- new form: the argument is passed through to `vllm` intact.

Worth recording why this survived earlier review: `bash -n` passes on **both** forms, so a syntax check says nothing here. Only running it distinguishes them.

**One residual nit, not a blocker:** `vllm` will still reject `<TP_SIZE>` at argparse as a non-integer. That is a docs-placeholder convention question (quoted inert placeholder vs. a concrete `-tp 2`), not the shell bug — and the PR body below already raises it and offers to switch. Worth a maintainer opinion, not a re-review.

---

## Original description (from #5, verbatim)

Three changes to the deploy commands on the Intel page. One fixes a command that can't run, one is a parser-name correction, and one is cosmetic — flagged as such below.

### `-tp $<TP_SIZE>` stops the command running at all

`$<` isn't placeholder syntax. Bash reads `<TP_SIZE` as "read input from a file called TP_SIZE", so it gives up before vllm starts. Verified against the real binary:

```
before   -tp $<TP_SIZE>    rc=1   TP_SIZE: No such file or directory
after    -tp "<TP_SIZE>"   rc=2   vllm serve: error: argument --tensor-parallel-size/-tp:
                                  invalid int value: '<TP_SIZE>'
```

In the first case vllm is never reached. Quoting makes the placeholder inert, so a reader gets an error naming the flag instead of a file they've never heard of. `bash -n` passes both, which is what makes this easy to miss in review.

I used a quoted placeholder rather than a concrete `-tp 2` because choosing a number means asserting a TP value for Xeon, and that's Intel's call. Happy to switch if you'd rather it match the concrete values used elsewhere on the page.

### Parser names need an underscore

`muse-glimmer` → `muse_glimmer`. vLLM matches these literally and errors on the hyphen; the [official recipe](https://recipes.vllm.ai/meta-models/Muse-Glimmer-30B) uses the underscore form in both flags. `--alias muse-glimmer`, the `--override-kv muse-glimmer.*` keys and the local directory name are left alone — none of those are registry lookups.

### `./muse-glimmer-bf16` — cosmetic, not a fix

I first claimed the bare name would be read as a Hugging Face repo id and fetched over the network. **That was wrong.** vLLM checks `Path(model).exists()` against the working directory before any hub lookup (`transformers_utils/repo_utils.py:207`), so a bare relative directory name resolves locally exactly like `./`. Confirmed by running both against a populated directory — both load the model and reach "Application startup complete".

Keeping the hunk only because it's more explicit and matches the `hf download --local-dir ./muse-glimmer-bf16` line directly above. Say the word and I'll drop it.

### Not included

`--trust-remote-code`. The checkpoint has no `auto_map` and `model_type: muse_glimmer` is handled natively, so there's nothing to trust. Left out to keep this PR to commands that don't run — happy to add it here if you'd prefer one change instead of two.
