### PR TITLE
vLLM: switch install path from pip to Docker, correct parser/sampling/VRAM guidance (recreates #11)

### DIFF
--- a/agentic-fundamentals/README.md
+++ b/agentic-fundamentals/README.md
@@ -165,7 +165,7 @@ To swap the backend for lower latency, point the same loop at a vLLM endpoint. T
 |---|---|---|
 | `TemplateError: arguments ... must be a dict` | Passed `arguments` as a JSON string | Pass the parsed dict into `apply_chat_template` (the loop does this). |
 | Model never stops or repeats | Wrong stop tokens | Use `eos_token_id=[<\|eot\|>, <\|end_of_text\|>]`; never `<\|eom\|>`. |
-| Tool calls arrive as plain text | Not parsing the tool block | Use `MuseGlimmerATEMParser` (or vLLM `--tool-call-parser muse-glimmer`). |
+| Tool calls arrive as plain text | Not parsing the tool block | Use `MuseGlimmerATEMParser` (or vLLM `--tool-call-parser muse_glimmer`). |
 | An echoed example call gets executed | Missing channel scoping | Strip `to=self` / `to=user` spans before scanning invokes (the parser does this). |
 | Agent stops before writing the report | Hit `--max-steps` | Raise `--max-steps`; one read per file adds up on large projects. |
 | OOM loading bf16 | ~60 GB doesn't fit | Use `device_map="auto"` across GPUs, or the vLLM path with tensor parallelism. |

--- a/inference-server/vllm.md
+++ b/inference-server/vllm.md
@@ -1,25 +1,33 @@
 # vLLM
 
-Serve Muse Glimmer with native tool calling and stream it to your whole team. This is the server every recipe in this cookbook is verified against.
+Serve Muse Glimmer with native tool calling and stream it to your whole team. This is the reference server for the agentic recipes in this cookbook.
 
 > [!NOTE]
-> Status: verified. vLLM ships a native `MuseGlimmerForCausalLM` (no `trust_remote_code`), a tool-call parser, a reasoning parser, and the Muse Glimmer chat template.
+> Status: unverified end to end. The commands below follow the [official vLLM recipe](https://recipes.vllm.ai/meta-models/Muse-Glimmer-30B), but nobody has attested a full run against this cookbook yet. What *is* confirmed: the `vllm/vllm-openai:muse-glimmer` image is published, and the `muse_glimmer` tool-call and reasoning parsers exist. What is *not* confirmed: that these exact flags serve cleanly on your hardware. If you complete a run, please say so in an issue so we can upgrade this banner.
 
 ## Install
 
+Docker is the supported path.
+
 ```bash
-pip install vllm
+docker pull vllm/vllm-openai:muse-glimmer
 ```
 
-What vLLM provides for Muse Glimmer:
+`pip install vllm` will **not** serve this model. Muse Glimmer support in vLLM is still an open, unmerged pull request ([vllm-project/vllm#51655](https://github.com/vllm-project/vllm/pull/51655)), so the model code and the `muse_glimmer` parsers are absent from every released wheel. The official recipe sets `pip: false` for exactly this reason. The image is how you get the unreleased code.
 
-| Area | File | Flag |
-|---|---|---|
-| Text model | `vllm/model_executor/models/muse_glimmer.py` | (auto) |
-| Tool-call parser | `vllm/tool_parsers/muse_glimmer_tool_parser.py` | `--tool-call-parser muse-glimmer` |
-| Reasoning parser | `vllm/reasoning/muse_glimmer_reasoning_parser.py` | `--reasoning-parser muse-glimmer` |
-| Chat template | `examples/tool_chat_template_muse_glimmer.jinja` | `--chat-template …` |
-| Config (native) | `vllm/transformers_utils/configs/muse_glimmer.py` | (auto: `muse-glimmer` / `muse_glimmer_text` / `muse_glimmer_vision`) |
+The image is ~10.5 GB and publishes `linux/amd64` and `linux/arm64`. The recipe pins it for CUDA 13.0 (`docker_image.nvidia.cu130`). There is no published ROCm image — on ROCm, build from PR #51655.
+
+What the image gives you for Muse Glimmer:
+
+| Capability | How you get it |
+|---|---|
+| Text model (`MuseGlimmerForCausalLM`) | Automatic. No `trust_remote_code`. |
+| Tool-call parser | `--tool-call-parser muse_glimmer` |
+| Reasoning parser | `--reasoning-parser muse_glimmer` |
+| Chat template | Ships with the checkpoint as `chat_template.jinja`. Don't pass `--chat-template`. |
+| Model config | Automatic (`muse-glimmer` / `muse_glimmer_text` / `muse_glimmer_vision`). |
+
+Parser names use **underscores** (`muse_glimmer`). vLLM matches them literally, so the hyphenated form fails. `--served-model-name muse-glimmer` is a label you choose and stays hyphenated.
 
 Vision (multimodal) is a fast-follow. Text and tool calling work today.
 
@@ -27,36 +35,81 @@ Full tool calling needs a checkpoint converted with the current HF Muse Glimmer 
 
 ## Serve
 
+The image sets `ENTRYPOINT ["vllm", "serve"]`. Everything after the image name is appended to that, so pass the model and flags directly — **do not** retype `vllm serve`, and don't reach for `python -m vllm.entrypoints.openai.api_server`.
+
 ```bash
-python -m vllm.entrypoints.openai.api_server \
-  --model meta-models/Muse-Glimmer-30B \
+docker run --rm --gpus all --ipc=host \
+  -p 8000:8000 \
+  -v ~/.cache/huggingface:/root/.cache/huggingface \
+  vllm/vllm-openai:muse-glimmer \
+  meta-models/Muse-Glimmer-30B \
   --served-model-name muse-glimmer \
+  --tensor-parallel-size 1 \
   --enable-auto-tool-choice \
-  --tool-call-parser muse-glimmer \
-  --reasoning-parser muse-glimmer \
-  --chat-template examples/tool_chat_template_muse_glimmer.jinja \
+  --tool-call-parser muse_glimmer \
+  --reasoning-parser muse_glimmer \
   --generation-config auto
 ```
 
-Single 80 GB card, tighter memory:
+Two things to know about that command. The flags from `--served-model-name` down are the recipe's own argument list for a single card. The `docker run` wrapper around them — `--gpus all`, `--ipc=host`, the port, the cache mount — is standard vLLM boilerplate rather than anything the recipe specifies; adjust it to your host. Mounting `~/.cache/huggingface` is what stops the container re-downloading ~60 GB of weights on every start.
+
+The recipe itself mounts pre-downloaded weights at `/model` instead of passing a Hub id:
 
 ```bash
-python -m vllm.entrypoints.openai.api_server \
-  --model meta-models/Muse-Glimmer-30B --served-model-name muse-glimmer \
-  --gpu-memory-utilization 0.9 --max-model-len 8300 --enforce-eager \
-  --enable-auto-tool-choice --tool-call-parser muse-glimmer --reasoning-parser muse-glimmer \
-  --chat-template examples/tool_chat_template_muse_glimmer.jinja --generation-config auto
+docker run --rm --gpus all --ipc=host \
+  -p 8000:8000 \
+  -v /path/to/Muse-Glimmer-30B:/model \
+  vllm/vllm-openai:muse-glimmer \
+  /model \
+  --served-model-name muse-glimmer \
+  --tensor-parallel-size 1 \
+  --enable-auto-tool-choice \
+  --tool-call-parser muse_glimmer \
+  --reasoning-parser muse_glimmer \
+  --generation-config auto
 ```
 
-Multi-GPU with tensor parallelism (bf16 needs ~60 GB, so use enough cards to cover it — e.g. 2× 40 GB or 4× 24 GB):
+Multi-GPU — raise `--tensor-parallel-size` to cover the model:
 
 ```bash
-python -m vllm.entrypoints.openai.api_server \
-  --model meta-models/Muse-Glimmer-30B --served-model-name muse-glimmer \
+docker run --rm --gpus all --ipc=host \
+  -p 8000:8000 \
+  -v ~/.cache/huggingface:/root/.cache/huggingface \
+  vllm/vllm-openai:muse-glimmer \
+  meta-models/Muse-Glimmer-30B \
+  --served-model-name muse-glimmer \
   --tensor-parallel-size 2 \
-  --enable-auto-tool-choice --tool-call-parser muse-glimmer --reasoning-parser muse-glimmer \
-  --chat-template examples/tool_chat_template_muse_glimmer.jinja --generation-config auto
+  --enable-auto-tool-choice \
+  --tool-call-parser muse_glimmer \
+  --reasoning-parser muse_glimmer \
+  --generation-config auto
 ```
+
+Tighter memory, at a cost in throughput and context:
+
+```bash
+docker run --rm --gpus all --ipc=host \
+  -p 8000:8000 \
+  -v ~/.cache/huggingface:/root/.cache/huggingface \
+  vllm/vllm-openai:muse-glimmer \
+  meta-models/Muse-Glimmer-30B \
+  --served-model-name muse-glimmer \
+  --gpu-memory-utilization 0.9 --max-model-len 8300 --enforce-eager \
+  --enable-auto-tool-choice \
+  --tool-call-parser muse_glimmer \
+  --reasoning-parser muse_glimmer \
+  --generation-config auto
+```
+
+> [!NOTE]
+> Budget **72 GB of VRAM** to serve, which is what the official recipe asks for. The bf16 weights are only ~60 GB; the rest is KV cache, activations and CUDA overhead. Sizing to the weights alone is the usual way to OOM shortly after startup.
+
+## Sampling
+
+Serve with `--generation-config auto`, as every command above does, and vLLM picks up the checkpoint's published sampling settings: **temperature 1.0, top_p 0.95, top_k 64**.
+
+> [!WARNING]
+> Don't run this model greedy. Passing `"temperature": 0` in a request overrides the published settings and the recipe explicitly advises against it. If you set sampling per-request, carry all three values rather than a bare temperature.
 
 ## Verify tool calling
 
@@ -71,11 +124,14 @@ curl http://localhost:8000/v1/chat/completions \
     "parameters":{"type":"object","properties":{
       "city":{"type":"string"},"units":{"type":"string","enum":["celsius","fahrenheit"]}},
       "required":["city"]}}}],
-  "tool_choice":"auto","temperature":0.0
+  "tool_choice":"auto"
 }'
 ```
 
-You get a `tool_calls` array with `get_weather(city="Paris", units="celsius")`, and the reasoning surfaced under `reasoning_content`.
+You get back `get_weather(city="Paris", units="celsius")`, with the reasoning surfaced under `message.reasoning` (`delta.reasoning` when streaming).
+
+> [!IMPORTANT]
+> Muse Glimmer emits **one tool call per message**. Several calls arrive as consecutive assistant messages, not as several entries in a single `tool_calls` array. Harnesses that read only the first element of the first message, or that assume one assistant message means one round of calls, will silently drop work.
 
 ## Stop tokens
 
@@ -90,10 +146,14 @@ Token IDs above come from the converted checkpoint. Confirm against your checkpo
 
 | Symptom | Cause | Fix |
 |---|---|---|
-| Tool calls returned as plain text | Parser or template missing | Pass both `--tool-call-parser muse-glimmer` and the Muse Glimmer chat template. |
+| `ValueError: model architectures ... are not supported` | Running a released vLLM wheel, not the image | The model code isn't in any wheel. Use `vllm/vllm-openai:muse-glimmer`. |
+| `invalid tool call parser` | Hyphenated parser name | Use underscores: `muse_glimmer`. |
+| Tool calls returned as plain text | Parser not enabled | Pass `--tool-call-parser muse_glimmer`. The chat template comes from the checkpoint. |
+| Only the first tool call runs | Harness expects a `tool_calls` array | One call per message — read consecutive assistant messages. |
 | Model runs forever | Wrong stop tokens | See above — never stop on `<\|eom\|>`. |
-| `to=self` reasoning leaking into content | No reasoning parser | Use `--reasoning-parser muse-glimmer`; it routes reasoning to `reasoning_content`. |
-| OOM | bf16 needs ~60 GB | Lower `--max-model-len`, add `--tensor-parallel-size`, or use a quant. |
+| `to=self` reasoning leaking into content | No reasoning parser | Use `--reasoning-parser muse_glimmer`; it routes reasoning to `message.reasoning`. |
+| Flat, repetitive answers | Running greedy | Don't send `"temperature": 0`. Use the published settings. |
+| OOM shortly after startup | Sized to the ~60 GB weights, not the 72 GB serving footprint | Lower `--max-model-len`, raise `--tensor-parallel-size`, or use a quant. |
 
 ## Next steps
 

--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -18,29 +18,36 @@ Every path here runs fully offline after the initial weight download. No API key
 > - bf16 lands around 59–60 GB: fits a single 80 GB card, or two cards with tensor parallelism.
 > - Q4_K_M / INT4 lands around 16–17 GB.
 >
-> Every recipe in this cookbook is verified at bf16 on vLLM. Quantized paths work, but we don't verify each recipe across quant schemes.
+> The agentic recipes in this cookbook target bf16 on vLLM. Quantized paths work, but we don't check each recipe across quant schemes.
 
 ## Serve with vLLM
 
 > [!NOTE]
-> Status: verified. This is the path to use for agentic tool calling.
+> Status: unverified end to end. This is the path to use for agentic tool calling, and it follows the official vLLM recipe, but no full run has been attested for this cookbook. Details in [`../inference-server/vllm.md`](../inference-server/vllm.md).
 
-vLLM has a native Muse Glimmer model (`MuseGlimmerForCausalLM`, no `trust_remote_code`) plus a tool-call parser and reasoning parser.
+vLLM has a native Muse Glimmer model (`MuseGlimmerForCausalLM`, no `trust_remote_code`) plus a tool-call parser and reasoning parser. They ship in a dedicated image — `pip install vllm` will not serve this model, because Muse Glimmer support is still an unmerged upstream PR and isn't in any released wheel.
 
 ```bash
-pip install vllm
+docker pull vllm/vllm-openai:muse-glimmer
 ```
 
+The image's entrypoint is already `vllm serve`, so everything after the image name is appended as arguments:
+
 ```bash
-python -m vllm.entrypoints.openai.api_server \
-  --model meta-models/Muse-Glimmer-30B \
+docker run --rm --gpus all --ipc=host \
+  -p 8000:8000 \
+  -v ~/.cache/huggingface:/root/.cache/huggingface \
+  vllm/vllm-openai:muse-glimmer \
+  meta-models/Muse-Glimmer-30B \
   --served-model-name muse-glimmer \
+  --tensor-parallel-size 1 \
   --enable-auto-tool-choice \
-  --tool-call-parser muse-glimmer \
-  --reasoning-parser muse-glimmer \
-  --chat-template examples/tool_chat_template_muse_glimmer.jinja \
+  --tool-call-parser muse_glimmer \
+  --reasoning-parser muse_glimmer \
   --generation-config auto
 ```
+
+Budget 72 GB of VRAM to serve — the bf16 weights are ~60 GB, and KV cache and activations need the rest.
 
 Test tool calling against the OpenAI-compatible endpoint:
 
@@ -61,7 +68,7 @@ curl http://localhost:8000/v1/chat/completions \
 }'
 ```
 
-You get back a structured `tool_calls` array with `get_weather(city="Paris", units="celsius")`.
+You get back `get_weather(city="Paris", units="celsius")`. Note that Muse Glimmer emits one tool call per message — several calls arrive as consecutive assistant messages, not as several entries in one `tool_calls` array.
 
 > [!WARNING]
 > Stop tokens matter. Set `eos_token_id = [<|end_of_text|>, <|eot|>]`. Don't add `<|eom|>` as a stop token: it's end-of-*message* (the turn continues), and stopping on it drops parallel tool calling to near zero. Details in [`../inference-server/vllm.md`](../inference-server/vllm.md).
@@ -132,9 +139,9 @@ For tool calling, use the vLLM path above: Ollama's default templates may not em
 | Symptom | Cause | Fix |
 |---|---|---|
 | Model never stops generating | Missing or wrong stop tokens | Set `eos_token_id=[<\|end_of_text\|>, <\|eot\|>]`. Don't include `<\|eom\|>`. |
-| Tool calls come back as plain text | Server isn't parsing the tool block | Use vLLM with `--tool-call-parser muse-glimmer`, or parse it yourself ([agentic-fundamentals](../agentic-fundamentals/)). |
+| Tool calls come back as plain text | Server isn't parsing the tool block | Use vLLM with `--tool-call-parser muse_glimmer`, or parse it yourself ([agentic-fundamentals](../agentic-fundamentals/)). |
 | OOM on a 24 GB card | Running bf16 (~60 GB) | Add tensor parallelism, or use a quantized build (Ollama, LM Studio). |
-| `trust_remote_code` prompt | Checkpoint ships custom modeling code | Use the native path: transformers ≥ 5.15, or serve with vLLM. |
+| `trust_remote_code` prompt | Checkpoint ships custom modeling code | Use the native path: transformers ≥ 5.15, or serve with the `vllm/vllm-openai:muse-glimmer` image. |
 
 ## Next steps
 

--- a/recipes/reasoning-effort/README.md
+++ b/recipes/reasoning-effort/README.md
@@ -43,7 +43,7 @@ Numbers vary by run and by problem — the point is the shape. Reasoning tokens 
 
 Two things worth knowing:
 
-- **`reasoning_content` is a separate field.** Muse Glimmer reasons in a `to=self` channel; vLLM's `--reasoning-parser muse_glimmer` routes it to `message.reasoning_content` and keeps `message.content` clean. Without that flag, reasoning leaks into your answer.
+- **`reasoning` is a separate field.** Muse Glimmer reasons in a `to=self` channel; vLLM's `--reasoning-parser muse_glimmer` routes it to `message.reasoning` (`delta.reasoning` when streaming) and keeps `message.content` clean. Without that flag, reasoning leaks into your answer. Note this model uses `reasoning`, not the `reasoning_content` some other models emit.
 - **Reasoning tokens are billed as completion tokens.** They count against `max_tokens`. An `xhigh` run that hits the ceiling mid-thought returns an empty answer — the most common way this bites.
 
 ## Make it yours

--- a/recipes/reasoning-effort/README.md
+++ b/recipes/reasoning-effort/README.md
@@ -43,7 +43,7 @@ Numbers vary by run and by problem — the point is the shape. Reasoning tokens 
 
 Two things worth knowing:
 
-- **`reasoning_content` is a separate field.** Muse Glimmer reasons in a `to=self` channel; vLLM's `--reasoning-parser muse-glimmer` routes it to `message.reasoning_content` and keeps `message.content` clean. Without that flag, reasoning leaks into your answer.
+- **`reasoning_content` is a separate field.** Muse Glimmer reasons in a `to=self` channel; vLLM's `--reasoning-parser muse_glimmer` routes it to `message.reasoning_content` and keeps `message.content` clean. Without that flag, reasoning leaks into your answer.
 - **Reasoning tokens are billed as completion tokens.** They count against `max_tokens`. An `xhigh` run that hits the ceiling mid-thought returns an empty answer — the most common way this bites.
 
 ## Make it yours
@@ -58,7 +58,7 @@ Two things worth knowing:
 | Symptom | Cause | Fix |
 |---|---|---|
 | Empty `answer`, high reasoning tokens | Hit `max_tokens` mid-thought | Raise `max_tokens`, or lower effort. |
-| Reasoning text appears in `content` | Reasoning parser not enabled | Serve with `--reasoning-parser muse-glimmer`. |
+| Reasoning text appears in `content` | Reasoning parser not enabled | Serve with `--reasoning-parser muse_glimmer`. |
 | `reasoning_tokens` is `n/a` | Server didn't report the breakdown | Cosmetic — `completion_tokens` still tells you the cost. |
 | Every setting is wrong | Problem too hard, or ceiling too low | Raise `max_tokens` first; then reconsider the task. |
 | `Connection refused` | Nothing served on the port | Start vLLM ([`../../inference-server/vllm.md`](../../inference-server/vllm.md)). |

--- a/recipes/reasoning-effort/reasoning_effort.py
+++ b/recipes/reasoning-effort/reasoning_effort.py
@@ -43,7 +43,7 @@ def ask(client: OpenAI, model: str, effort: str) -> dict:
     message = resp.choices[0].message
     answer = (message.content or "").strip()
     # Muse Glimmer's `to=self` channel is routed here by vLLM's reasoning parser.
-    reasoning = getattr(message, "reasoning_content", None) or ""
+    reasoning = getattr(message, "reasoning", None) or ""
 
     usage = resp.usage
     details = getattr(usage, "completion_tokens_details", None)


### PR DESCRIPTION
Recreates #11, which GitHub auto-closed during a history-rewrite attempt that was rolled back. Branch and commits are unchanged; the original review thread is still readable at #11.

The old PR object cannot be reopened — GitHub has latched it (`422 branch has no history in common with main`), and reopening was already exhausted via GraphQL, REST, and ref-update events. Head is still `c53221a`, identical to what #11 pointed at.

---

## Review status carried over from #11

- **This supersedes #4** (`fix/vllm-parser-names-and-chat-template`, @p-bhende). Re-verified against the branches at recreation time: every change in #4 is present here. `agentic-fundamentals/README.md` is byte-identical between the two branches; the `quickstart/README.md` and `recipes/reasoning-effort/README.md` changes from #4 are all present here, inside larger edits. In `vllm.md` there is no hyphenated `--tool-call-parser` / `--reasoning-parser` left anywhere in this branch, and `--chat-template` is not passed in any command. Because of that, **#4 is not being recreated as a separate PR** — it would conflict with this one in `inference-server/vllm.md` and `recipes/reasoning-effort/README.md` (confirmed by `git merge-tree`) while adding nothing. His contribution rides in this branch; credit belongs to him for finding both bugs.
- **Banner downgraded to "unverified end to end"** — see the dedicated section below for the reasoning and for exactly what evidence would restore a stronger claim.

---

## Original description (from #11, verbatim)

`inference-server/vllm.md` told readers to `pip install vllm` under a banner reading **"Status: verified."** pip cannot serve this model at all, so every reader of that page failed on the first command.

## Why pip can't work

Muse Glimmer support in vLLM is an **open, unmerged PR** ([vllm-project/vllm#51655](https://github.com/vllm-project/vllm/pull/51655)). vLLM `main` has no muse/glimmer entry in `model_executor/models/registry.py`, and no `muse_glimmer` file under `vllm/reasoning/` or `vllm/tool_parsers/`. None of it is in a released wheel. The [official recipe](https://recipes.vllm.ai/meta-models/Muse-Glimmer-30B) states this outright:

```yaml
install:
  docker:
    note: "Docker is the supported path — the model code and the muse_glimmer
           parsers are not in any released vLLM wheel."
  pip: false
```

## What changed

**Docker replaces pip.** `vllm/vllm-openai:muse-glimmer`, pinned by tag. The recipe pins it under `docker_image.nvidia.cu130`; ROCm has no published image, so that case points at building from #51655.

**All three serve invocations were reworked, not patched.** The image's `ENTRYPOINT` is `["vllm", "serve"]` (`docker/Dockerfile:1019`), so `python -m vllm.entrypoints.openai.api_server` is gone everywhere and args are appended after the image name. The page now says explicitly not to retype `vllm serve` inside `docker run`, which is the easy mistake here.

**The "what vLLM provides" table** listed source-tree paths (`vllm/model_executor/models/muse_glimmer.py`, …). Those mean nothing to someone running a container, so it now maps capability → the flag you actually pass.

I kept the recipe's own argument list intact and showed both the HF-cache form and the recipe's `/model` mount form. The recipe stores an image plus args — there is no literal `docker run` string in it — so the `--gpus all --ipc=host -p 8000:8000 -v ~/.cache/huggingface:…` wrapper is labelled in the page as standard vLLM boilerplate rather than presented as official.

Other verified corrections on the same pages:

| Was | Now |
|---|---|
| `--tool-call-parser muse-glimmer` | `muse_glimmer` — underscores. Registered at `muse_glimmer_tool_parser.py:183` / `muse_glimmer_reasoning_parser.py:106`. `--served-model-name muse-glimmer` stays hyphenated; it's only a label. |
| `--chat-template examples/tool_chat_template_muse_glimmer.jinja` | Dropped as **redundant** — the checkpoint ships `chat_template.jinja` at repo root and the recipe never passes the flag. |
| reasoning under `reasoning_content` | `message.reasoning` / `delta.reasoning`. |
| `"temperature": 0.0` | Removed. Published settings are temperature 1.0, top_p 0.95, top_k 64; the recipe says not to run it greedy. |
| "You get back a `tool_calls` array" | One call **per message**, arriving as consecutive assistant messages. Harnesses reading only the first element silently drop work. |
| OOM guidance at ~60 GB | 72 GB to serve (`vram_minimum_gb: 72`). ~60 GB is weights only — sizing to that is how you OOM just after startup. |

Stop tokens already matched the recipe and are untouched.

## This supersedes #4 — @p-bhende's changes are kept

[#4](https://github.com/meta-models/meta-oss-cookbook/pull/4) found two real bugs and got **both fixes right**. Every one of its changes is in this branch, including all three files outside `vllm.md` (`agentic-fundamentals/README.md`, `quickstart/README.md`, `recipes/reasoning-effort/README.md`) — the diffs for those files here are byte-identical to #4's.

What this PR corrects is the *reasoning*, not the changes:

- #4 argues from `pip install vllm`. That path was never supported, so the premise doesn't hold — which matters, because it makes the fix look optional if you happen to install some other way.
- #4 says the `--chat-template` path is unresolvable. It isn't: `Dockerfile:606` sets `WORKDIR /vllm-workspace` and `:847` copies `examples`, so it *would* resolve. The right reason to drop the flag is redundancy. #4's own second paragraph actually gets this right; the title and framing are what's off.

I'm deliberately not closing #4 — that's the maintainers' call.

## On the "verified" banner

I downgraded `vllm.md:6` and the matching banner in `quickstart/README.md` from **"Status: verified"** to *unverified end to end*.

The reason is narrow and I want to be precise about it: the previously documented install path could not have worked, so whatever "verified" referred to, it wasn't the commands on the page. Nobody has attested a Docker-based run for this cookbook either. Leaving a verification claim on top of a page whose first command fails is the specific problem worth fixing.

I've tried not to overcorrect into hedging everything, because plenty here is solid. The banner still states what is confirmed: the image is published (Docker Hub, updated 2026-08-10, 10.5 GB, `linux/amd64` + `linux/arm64`), and the tool-call and reasoning parsers demonstrably exist. The flags come from the official recipe, not from guesswork. The NLL parity appendix is measured data and I left it alone.

**To restore a stronger claim**, what's needed is an attested run: `docker run` with the pinned tag on named hardware, reaching a healthy `/v1/models`, plus one tool-calling request showing a parsed call and `message.reasoning` populated — and the VRAM actually observed. Post that and I'll happily put "verified" back, scoped to that configuration. If someone on the team has already done this run, say so and this is a one-line change.

## Known gaps

**Update:** the `reasoning_content` item below was originally left as a follow-up. On review I reversed that call and fixed it in `c53221a` — see the note at the end.

1. ~~**`reasoning_content` in the reasoning-effort recipe.**~~ **Fixed.** `recipes/reasoning-effort/reasoning_effort.py:46` read `getattr(message, "reasoning_content", ...)`, so `--show-reasoning` printed nothing; `README.md:46` documented the same wrong field. Both now use `reasoning`. Token counts come from `usage`, not this field, so the recipe's published results table is unaffected.

2. **Still open: `reasoning_effort.py:39` sets `temperature=0.0`.** Same greedy problem this PR fixes elsewhere, but changing it alters that recipe's published results table (README lines 32–35), which needs an actual re-run to regenerate. Not something to change blind, so it stays for whoever can re-run it.

3. **Still open: `agentic-fundamentals/agent_loop.py:153`** writes `assistant_msg["reasoning_content"] = turn.reasoning`. That is the *request* direction — building an assistant message to send back — not reading a response. I have not verified what the server expects on input, and the recipe's `reasoning` finding covers output surfacing only. Left alone rather than changed on an assumption.

### Note on the reversal

I first left item 1 as a follow-up, reasoning that the README should match its shipped script. That was wrong: the README line documents *vLLM's output field*, an external fact, not the script's behaviour — so leaving it propagated the error rather than preserving accuracy. It also meant this PR shipped `vllm.md` saying `message.reasoning` while the reasoning-effort page said `message.reasoning_content`, a self-contradiction in a PR whose whole point is correcting factual API claims. Fixing the prose while knowingly leaving the one-line bug that makes the prose false was the worse option. Both are one commit, `c53221a`, and trivially revertible if maintainers would rather keep this PR strictly to the vLLM pages.

## Scope

`inference-server/vllm.md`, `quickstart/README.md`, plus #4's changes to `agentic-fundamentals/README.md` and `recipes/reasoning-effort/README.md`. No other server pages touched (#6, #7, #9, #10 are open on those). `platform/intel.md` also carries hyphenated parser names, but that's #5's territory.

---

*Footnote on cross-references: the verbatim description above cites PR numbers as they were at the time (#4, #5, #6, #7, #9, #10). Those objects were all auto-closed by the same rolled-back history rewrite; where a replacement PR exists it is linked from the closed original. #5 is now #13.*
