### PR TITLE
llama.cpp: replace master-only guidance with a b10353 version floor

### DIFF
--- a/inference-server/llama-cpp.md
+++ b/inference-server/llama-cpp.md
@@ -3,7 +3,7 @@
 Portable inference across CPU, Metal, CUDA, ROCm and Vulkan — the practical way to run Muse Glimmer on a single machine.
 
 > [!NOTE]
-> Status: verified on Apple silicon (Metal) against upstream llama.cpp at commit `dd1ea52` — text, vision and tool calling, against ready-to-serve GGUF checkpoints. There is no conversion or quantization step.
+> Status: verified on Apple silicon (Metal) against upstream llama.cpp release `b10355` (commit `dd1ea52`) — text, vision and tool calling, against ready-to-serve GGUF checkpoints. There is no conversion or quantization step.
 
 Upstream llama.cpp supports Muse Glimmer. Commit [`62bf73d25`](https://github.com/ggml-org/llama.cpp/commit/62bf73d25) ("model: Muse Glimmer Support", PR #26841) adds the `muse-glimmer` architecture, the vision projector, the ATEM tool-call parser and DFlash speculative decoding. No fork is needed.
 
@@ -29,15 +29,29 @@ hf download meta-models/Muse-Glimmer-30B-GGUF --local-dir ./muse-glimmer \
 
 Full-precision weights are not published as GGUF. For bf16, use the safetensors checkpoint at [`meta-models/Muse-Glimmer-30B`](https://huggingface.co/meta-models/Muse-Glimmer-30B) with [`vllm.md`](vllm.md).
 
-### 2. Build
+### 2. Get llama.cpp
+
+Muse Glimmer support first shipped in release [`b10353`](https://github.com/ggml-org/llama.cpp/releases/tag/b10353). **Use `b10353` or newer** — a prebuilt binary and a source build both work.
+
+> [!IMPORTANT]
+> `b10344` and older do not register the `muse-glimmer` architecture and refuse to load these checkpoints:
+>
+> ```
+> llama_model_load: error loading model: unknown model architecture: 'muse-glimmer'
+> ```
+>
+> `llama-server --version` prints the build number to check against: `version: 10353 (...)` or higher.
+
+The [releases page](https://github.com/ggml-org/llama.cpp/releases) publishes prebuilt binaries for macOS arm64 (Metal), Linux (CPU, CUDA, ROCm, Vulkan, SYCL) and Windows. If you take one, unpack it and skip to [Serve](#serve) — read `./build/bin/` in the commands below as the directory you unpacked.
+
+To build from source instead — `master` is well past the floor:
 
 ```bash
 git clone https://github.com/ggml-org/llama.cpp
 cd llama.cpp
 ```
 
-> [!IMPORTANT]
-> Build from `master`. Muse Glimmer support landed on 2026-08-10 and is not in any tagged release yet — the newest tag at the time of writing, `b10343`, is six commits behind `62bf73d25` and does not register the `muse-glimmer` architecture, so the prebuilt release binaries cannot load these checkpoints.
+Add `--branch b10353` to pin to the floor, or any later tag to pin to a known build.
 
 Pick your backend:
 
@@ -66,7 +80,7 @@ cmake --build build -j"$(nproc)"             --target llama-server llama-cli lla
 
 If `ccache` errors during the build, add `-DGGML_CCACHE=OFF`.
 
-Run the commands below from the `llama.cpp` clone, with the `muse-glimmer/` download directory inside it, so both `./build/bin/` and `./muse-glimmer/` resolve. Otherwise pass absolute paths to `-m` and `--mmproj`.
+Run the commands below from the `llama.cpp` clone (or the unpacked release directory), with the `muse-glimmer/` download directory inside it, so both `./build/bin/` and `./muse-glimmer/` resolve. Otherwise pass absolute paths to `-m` and `--mmproj`.
 
 ## Serve
 


### PR DESCRIPTION
## Why

`llama-cpp.md` told readers that Muse Glimmer support was on `master` only, that no tagged release had it, and that "the prebuilt release binaries cannot load these checkpoints." That was true when it was written this afternoon. It stopped being true at **22:00Z today**, when release `b10353` shipped with the architecture.

The page was sending every reader down a source build for no reason. This replaces the moment-in-time claim with a version floor.

## What I verified

Re-checked against upstream just now rather than trusting the earlier numbers — llama.cpp cut releases roughly every 40 minutes today. Grepping `src/llama-arch.cpp` for `LLM_ARCH_MUSE_GLIMMER` at each tag:

| tag | published | arch registered |
|---|---|---|
| `b10338` | 10:51Z | no |
| `b10342` | 12:47Z | no |
| `b10343` | 15:18Z | no |
| `b10344` | 16:24Z | no |
| **`b10353`** | **22:00Z** | **yes — first release** |
| `b10354` | 22:38Z | yes |
| `b10355` | 23:15Z | yes (newest at time of writing) |

There are no release tags between `b10344` and `b10353`, so `b10353` is the floor.

The floor holds for the whole feature surface, not just the arch enum. Comparing `b10344` → `b10353`, Muse Glimmer references appear in `src/llama-model.cpp`, `tools/mtmd/clip.cpp` and `clip-impl.h` (vision projector), `common/chat.cpp` (ATEM tool-call parser) and `gguf-py/gguf/constants.py`. Commit `62bf73d25` is 4 commits behind `b10353`. Prebuilt assets for `b10353` cover macOS arm64, Linux (CPU/CUDA/ROCm/Vulkan/SYCL) and Windows — i.e. the backends this page names.

**Failure mode for older binaries**, read from source at `b10344`: `llama_model_create` throws `unknown model architecture: 'muse-glimmer'` (`src/llama-model.cpp`), surfaced by the `llama_model_load` catch as `error loading model: ...`. I quoted that string in the page. This is derived from the source at that tag; I did not run a `b10344` binary against the checkpoint.

One bonus find: the page's verified Metal run was recorded against commit `dd1ea52`, which is **identical to tag `b10355`**. So the status note now names the tag as well as the commit — a reader can match it to the floor.

## What changed

Only `inference-server/llama-cpp.md`.

- `### 2. Build` → `### 2. Get llama.cpp`, since building is no longer the only path.
- The `master`-only IMPORTANT block is replaced by the floor: use `b10353` or newer; `b10344` and older refuse to load, with the error string and `llama-server --version` as the check.
- Prebuilt binaries are now the first option, with a pointer to skip to Serve.
- Source build kept and unchanged, with a note that `master` is well past the floor and how to pin.
- The path sentence before Serve now covers an unpacked release directory as well as a clone.

Untouched: the upstream rewrite, the verified Metal run, the `reasoning_strength` table, stop tokens, vision, tool calling.

## On PR #10 / `inference-server/README.md`

The brief said #10 added a pre-release note to `inference-server/README.md` naming llama.cpp as `master`-only, and to fix it here if it merged. **#10 did merge** (21:51Z), **but it did not add that note — it did the opposite.** #10 deleted the Status table from that README and replaced it with a plain page list. The row it removed said `llama.cpp | Verified (GGUF: text, vision, tool calling)`; nothing about `master`.

I grepped every ref in the repo for the stale phrasing. It exists in exactly one file, `inference-server/llama-cpp.md`, and the other branches carry it only because they forked from `main`. So nothing else needed fixing, and there was no unmerged branch to report. #13, #14, #15 do not touch `llama-cpp.md`, so there is no conflict and no risk of one of them reintroducing the old text.

## Recommendation on the wider pattern

Yes — these claims should be written as floors, and this PR is the argument for it. The old sentence was three facts fused together: *what the newest tag is*, *how far behind it is*, and *therefore what you must do*. Only the third is what the reader needs, and the first two are what rotted. It had a shelf life of about six hours.

The rule I would apply to all three pages: **assert the earliest version that works, never the latest version that exists.** A floor is monotonic — new releases can only confirm it, never falsify it. "Use `b10353` or newer" stays true for as long as upstream doesn't remove the feature. "`b10343` is the newest tag" was false before the day ended.

Concretely, for the other two:

- **SGLang (unreleased branch).** Same shape, same fate — it will get a release, and the page will then be wrong in this exact way. Write it so the branch instruction is scoped: name the commit or feature that makes it work, and state the floor as "not yet in a release as of `<date>` — check the releases page." The dated hedge is what the current llama.cpp text was missing; it asserted a present tense with no expiry.
- **vLLM (unmerged PR).** An unmerged PR genuinely is a moment in time, so it can't be a floor yet. But it can be written to fail loudly instead of silently: name the PR number and link it, so a reader who finds it merged knows the page is behind. Right now these pages read as settled fact, which gives the reader no signal that the ground moved.

Where a claim has to describe a moment, date it and give the reader the URL to re-check. Where it can be a floor, make it a floor. No restructuring needed for either — this is a sentence-level change on each page.
