### PR TITLE
docs: drop a redundant reasoning-format flag from the serve commands

### DIFF
--- a/inference-server/llama-cpp.md
+++ b/inference-server/llama-cpp.md
@@ -93,7 +93,6 @@ Muse Glimmer supports a native context of **131072**:
   -ngl 99 -c 131072 -np 1 \
   --host 127.0.0.1 --port 8080 --api-key <your-key> \
   --jinja \
-  --reasoning-format deepseek \
   --chat-template-kwargs '{"reasoning_strength":"low"}'
 ```
 
@@ -112,11 +111,12 @@ flag overrides this. Fix the metadata with the script in the llama.cpp clone
 | Flag | Why |
 |---|---|
 | `--jinja` | Applies the Muse Glimmer control-token template embedded in the GGUF. Without it, tool calling and reasoning separation break. |
-| `--reasoning-format deepseek` | Routes the thinking channel to `message.reasoning_content`, leaving `message.content` clean. |
 | `--chat-template-kwargs` | Sets `reasoning_strength` — see below. Template default is `high`. |
 | `-np N` | Concurrent slots, and **the context is divided N ways**: `-np 4` with `-c 131072` gives each slot 32768. Long-context agents want `-np 1`. |
 | `-ngl 99` | Offload all layers to the GPU. |
 | `--api-key` | Guards inference endpoints only; `/health` and `/v1/models` still answer without it. |
+
+Thinking lands in `message.reasoning_content` and `message.content` stays clean — that is the server default, no flag needed. Pass `--reasoning-format none` to keep thinking inline in `message.content` instead.
 
 Drop `--mmproj` for text-only. For speculative decoding add `-md <draft>.gguf --spec-type draft-dflash -ngld 99 --spec-draft-n-max 4`.
 

--- a/recipes/computer-use-web/README.md
+++ b/recipes/computer-use-web/README.md
@@ -30,7 +30,6 @@ Follow [`../../inference-server/llama-cpp.md`](../../inference-server/llama-cpp.
   -ngl 99 -c 131072 -np 1 \
   --host 127.0.0.1 --port 8080 --api-key muse-glimmer \
   --jinja \
-  --reasoning-format deepseek \
   --chat-template-kwargs '{"reasoning_strength":"high"}'
 ```
 


### PR DESCRIPTION
The `llama-server` examples passed an explicit `--reasoning-format` value that is **already the server default**, so it never changed behaviour.

### Why this is safe

Verified by reading upstream llama.cpp at tag **`b10355`** (`dd1ea5243`) — at or above the `b10353` version floor this repo documents:

| Check | Result |
|---|---|
| `common_params::reasoning_format` default | Already the same enum value the flag was setting (`common/common.h:632`) — passing it was a literal no-op |
| Does the server override it? | No. It is handed straight through (`tools/server/server-schema.cpp:535`, `tools/server/server-context.cpp:1534`) |
| Parser gating | All 11 extraction sites in `common/chat.cpp` gate on `reasoning_format != COMMON_REASONING_FORMAT_NONE` |
| Any value-specific branch? | Only the `-legacy` variant is ever special-cased (`tools/server/server-schema.cpp:303`, `:553`) |
| Is `auto` equivalent? | Yes — `common/common.h:413` documents it as equivalent to the value being passed, routing into `message.reasoning_content` the same way. Both candidate defaults route thinking identically |

Only `--reasoning-format none` changes observable behaviour. Removing the flag does not.

### Changes

- `inference-server/llama-cpp.md` — dropped from the serve command. The flag's table row is dropped with it (its only purpose was documenting this flag) and replaced by a sentence stating the default routing, so readers still learn that thinking lands in `message.reasoning_content` and that `none` is the opt-out.
- `recipes/computer-use-web/README.md` — dropped from the serve command.

### Deliberately not changed

- `platform/intel.md` — Intel-supplied commands on a partner-contributed page. Editing a partner's submitted commands is not this PR's call, so both one-liners are left exactly as contributed.

### Verification

- `python platform/validate.py` → 0 errors, 0 warnings
- Net diff is 2 files; `platform/intel.md` is untouched

Docs only; no behaviour change.

