### PR TITLE
inference-server: say why ExecuTorch, and what it cannot do yet

### DIFF
--- a/inference-server/executorch.md
+++ b/inference-server/executorch.md
@@ -7,6 +7,8 @@ Export Muse Glimmer ahead of time and serve it locally on CUDA or Apple silicon,
 
 Unlike the other servers here, ExecuTorch is ahead-of-time: the model is exported once into a `.pte` program for a specific backend, then served from that program.
 
+That is the point of it. The other runtimes on this list reimplement a model by hand per backend, which works for a plain text transformer but not for a novel architecture carrying multimodal input and block-diffusion speculative decoding — each backend would need its own rewrite of all three. With ExecuTorch the model and its decoding strategy are written once in PyTorch and `torch.export` lowers the whole graph ahead of time, to Triton on CUDA and to MLX-native or custom Metal kernels on Apple silicon.
+
 | Backend | Host | Artifacts written by a local export |
 |---|---|---|
 | CUDA | Linux or Windows | `model.pte` plus `aoti_cuda_blob.ptd` |
@@ -64,6 +66,8 @@ python -m executorch.examples.models.muse_glimmer.export.export_dflash \
   --backend "$BACKEND" \
   --output-dir exports/dflash
 ```
+
+Both land in one `.pte`: the draft shares the target's token embeddings and output head rather than carrying copies. The block dimension is exported dynamically, so block length is selectable at serve time — but the exported range is backend-specific, `[2, 16]` on MLX against `[2, 4]` on CUDA, where the draft count is also capped at 3.
 
 Add `--mmproj "$MMPROJ"` to either command for vision; that also writes `pos_embed.bin` beside `model.pte`.
 
@@ -166,6 +170,16 @@ Two OpenAI parameters are rejected with a structured 400 rather than silently ig
 ## Stop tokens
 
 Muse Glimmer needs `eos_token_id = [<|end_of_text|>, <|eot|>]`. Never stop on `<|eom|>`. See [`README.md`](README.md#get-stop-tokens-right).
+
+## Limitations
+
+Runtime limits, not model limits — the [model card](https://huggingface.co/meta-models/Muse-Glimmer-30B) covers the latter.
+
+- **No video input.** Text and images only, one image per request.
+- **No continuous batching.** One request runs at a time: `--num-runners` must be 1, the exported methods are batch-1, and execution is serialized. Concurrent sessions are isolated from each other, not served in parallel.
+- **No cross-session prefix sharing and no checkpointing.** Every session holds its own KV cache, nothing is reused across sessions, and session state is discarded rather than saved.
+
+The upstream [announcement](https://pytorch.org/blog/fast-ondevice-agentic-ai-with-executorch/) lists all three as in progress. If you need concurrent throughput from one box today, use [`vllm.md`](vllm.md).
 
 ## Troubleshooting
 


### PR DESCRIPTION
`executorch.md` explained how to export and serve, but never why this path exists, and it published none of the runtime's stated limits. Both are in the upstream announcement, [Fast on-device agentic AI with ExecuTorch](https://pytorch.org/blog/fast-ondevice-agentic-ai-with-executorch/), which the page already links but only leans on for performance numbers.

Every claim below was cross-checked against the model source in `examples/models/muse-glimmer` before being written down.

## What changed

- **Why an export.** One paragraph after the ahead-of-time line: other runtimes reimplement per backend, which does not scale to a novel architecture plus multimodal input plus block-diffusion speculative decoding. `torch.export` lowers the graph once, to Triton on CUDA and MLX-native or custom Metal on Apple silicon.
- **A `Limitations` section**, before Troubleshooting: no video input, no continuous batching, no cross-session prefix sharing or checkpointing.
- **Two DFlash facts** in the export step: target and draft land in one `.pte` because the draft shares the target's token embeddings and output head, and the dynamic block dimension has a backend-specific range — `[2, 16]` on MLX against `[2, 4]` on CUDA, where the draft count is also capped at 3. The page previously implied block length was freely tunable.

## Deliberately not imported

- **The announcement's throughput numbers.** They are PyTorch's measurements on their hardware, and the page's existing NOTE already attributes them. Nothing here claims a number we did not run.
- **Its quickstart commands.** They use `model.pte` / `aoti_cuda_blob.ptd`, which exist only for a local export. This page already warns that those filenames fail against a downloaded artifact, so reintroducing them would undo that.

Section order and the "supported upstream" status are unchanged.
