### PR TITLE
hosted: add Together AI, corrected against their published model page

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ A local agent running on your own machine that completes a real multi-step task,
 | Ship a flagship agent (structured output, reasoning control, a triage pipeline) | [`recipes/`](recipes/) |
 | Serve Muse Glimmer (vLLM, Ollama, LM Studio, SGLang, llama.cpp) | [`inference-server/`](inference-server/) |
 | Deploy on specific partner hardware, and see which precisions it supports | [`platform/`](platform/) |
+| Call a hosted API instead of running the model yourself (needs a provider API key) | [`hosted/`](hosted/) |
 
 ## How every recipe is built
 

--- a/hosted/README.md
+++ b/hosted/README.md
@@ -1,0 +1,19 @@
+# Hosted
+
+Muse Glimmer served as an API by providers who run the hardware for you. One page per provider: the exact model string, what the provider publishes about it, what it costs, and a call that proves tool calling works.
+
+| Provider | Model string | Page |
+|---|---|---|
+| Together AI | `meta-models/Muse-Glimmer-30B` | [`together-ai.md`](together-ai.md) |
+
+## Why this sits in a local-first cookbook
+
+Muse Glimmer is open-weight, and the rest of this repo is local-first on purpose: everything from [`quickstart/`](../quickstart/) onward runs on your own hardware, offline, with no API key and no gated access. That is the point of the model and it doesn't change. Open weights also mean nobody is forced to operate the hardware themselves — this folder is for when you'd rather someone else did, and it is the one place in the repo where an account and an API key are required.
+
+If that trade isn't what you want, the alternatives are already here: [`inference-server/`](../inference-server/) to serve it yourself, [`platform/`](../platform/) for specific hardware.
+
+## How to read a provider page
+
+- **The model string is the contract.** It is the only thing your code needs, and it is the first thing on every page. Providers pick their own; it will not match the HuggingFace repo name.
+- **Provider numbers belong to the provider.** Performance figures, quantization details and quality evals are attributed and dated. They are not re-run here, and they describe the provider's serving stack — not something you configure.
+- **Prices and limits go stale.** Each page states the date it was read from the provider's own page, which is linked. Check it against the provider before you budget on it.

--- a/hosted/together-ai.md
+++ b/hosted/together-ai.md
@@ -1,0 +1,159 @@
+---
+vendor: Together AI
+contact: Mourya Vangala Srinivasa (msrinivasa@together.ai)
+updated: 2026-08-11
+---
+
+# Together AI
+
+Together AI serves Muse Glimmer as a managed API. There are no weights to download, no runtime to install, and no GPU to own — you send requests to `https://api.together.xyz/v1/chat/completions` with a model string and an API key.
+
+**This page requires an API key.** That is the trade the rest of this cookbook doesn't make; see [`README.md`](README.md) for why the folder exists.
+
+Everything under "What Together publishes" is taken from Together's model page, [together.ai/models/muse-glimmer](https://www.together.ai/models/muse-glimmer), read on 2026-08-11. Anything Together measured but doesn't publish there is marked as theirs.
+
+## The model string
+
+```
+meta-models/Muse-Glimmer-30B
+```
+
+That string is the whole integration. It is what Together lists as the endpoint on the model page, and it's what appears in all three of their published examples.
+
+## What Together publishes
+
+| | |
+|---|---|
+| Endpoint | `meta-models/Muse-Glimmer-30B` |
+| Provider | Meta |
+| Type | Chat, Vision |
+| Deployment | Serverless, Dedicated |
+| Parameters | 30B |
+| Context length | 128K+ |
+| Input modalities | Text, Image |
+| Output modalities | Text |
+| Input price | $0.35 / 1M tokens ($0.04 / 1M cached) |
+| Output price | $1.50 / 1M tokens |
+| Released | August 10, 2026 |
+| License | Apache 2.0 |
+| Availability | 99.9% SLA, serverless and dedicated |
+
+Tool calling is supported through the model's chat template, which is what makes this endpoint usable for the agent loops in [`../agentic-fundamentals/`](../agentic-fundamentals/).
+
+## Get a key
+
+```bash
+export TOGETHER_API_KEY=...   # https://api.together.xyz/settings/api-keys
+```
+
+Check that it works and that the model is visible to your account:
+
+```bash
+curl -s https://api.together.xyz/v1/models \
+  -H "Authorization: Bearer $TOGETHER_API_KEY" | grep -o 'meta-models/Muse-Glimmer-30B'
+```
+
+## Call it
+
+Together publishes three clients. The curl form is the one to reach for when you want to see the wire format:
+
+```bash
+curl -X POST "https://api.together.xyz/v1/chat/completions" \
+  -H "Authorization: Bearer $TOGETHER_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "meta-models/Muse-Glimmer-30B",
+    "messages": [
+      {"role": "user", "content": "What are some fun things to do in New York?"}
+    ]
+  }'
+```
+
+Python, using Together's official SDK (`pip install together`; it reads `TOGETHER_API_KEY` from the environment):
+
+```python
+from together import Together
+
+client = Together()
+response = client.chat.completions.create(
+    model="meta-models/Muse-Glimmer-30B",
+    messages=[{"role": "user", "content": "What are some fun things to do in New York?"}],
+)
+print(response.choices[0].message.content)
+```
+
+TypeScript, using `together-ai`:
+
+```javascript
+import Together from 'together-ai';
+
+const together = new Together();
+const completion = await together.chat.completions.create({
+  model: 'meta-models/Muse-Glimmer-30B',
+  messages: [{ role: 'user', content: 'What are some fun things to do in New York?' }],
+});
+console.log(completion.choices[0].message.content);
+```
+
+The path, the bearer header and the `{model, messages}` body are the OpenAI chat-completions wire format, so an HTTP client you already have pointed at `https://api.together.xyz/v1` will speak to it.
+
+## Prove tool calling works
+
+A response with text in it only proves the endpoint is up. The bar in this cookbook is a tool-calling round trip — expect `tool_calls` in the response, not prose:
+
+```bash
+curl -s https://api.together.xyz/v1/chat/completions \
+  -H "Authorization: Bearer $TOGETHER_API_KEY" -H "Content-Type: application/json" \
+  -d '{
+    "model": "meta-models/Muse-Glimmer-30B",
+    "messages": [{"role": "user", "content": "Weather in Paris, Tokyo and Cairo?"}],
+    "tools": [{"type": "function", "function": {"name": "get_weather",
+      "description": "Get current weather for a city",
+      "parameters": {"type": "object", "properties": {"city": {"type": "string"}},
+                     "required": ["city"]}}}]
+  }'
+```
+
+A working call returns three parallel `tool_calls` entries — one per city — in a single assistant turn, with reasoning available separately on the response object.
+
+You can also drive the same prompt from Together's playground: [api.together.ai/playground/meta-models/Muse-Glimmer-30B](https://api.together.ai/playground/meta-models/Muse-Glimmer-30B).
+
+## Behavior worth knowing
+
+**Sampling.** Defaults come from the checkpoint: `temperature 0.95`, `top_p 1.0`. Greedy decoding loops on this model, so don't set `temperature 0`.
+
+> [!WARNING]
+> Stop tokens: `eos_token_id = [<\|end_of_text\|>, <\|eot\|>]`. Never add `<\|eom\|>` to a `stop` parameter — it marks end-of-*message*, the turn continues after it, and stopping there reduces parallel tool calling to near zero. Background: [`../inference-server/README.md`](../inference-server/README.md).
+
+**Weights.** Nothing here downloads them, but if you want the model card or want to run the same model locally instead, it's the public repo the rest of this cookbook uses: [meta-models/Muse-Glimmer-30B](https://huggingface.co/meta-models/Muse-Glimmer-30B) on HuggingFace.
+
+## What Together measured
+
+Not on the model page — these are Together's own numbers, reported by Mourya Vangala Srinivasa on 2026-08-10. They are not reproduced here, and they describe Together's serving stack rather than anything you configure.
+
+| Metric | Value |
+|---|---|
+| TTFT p50 | 307 ms |
+| Output tokens/s per request | 105 |
+
+Measured on a dedicated 2×H100-80GB tensor-parallel replica under a sustained 0.4 QPS long-context replay: mean input 58,290 tokens (p99 ≈ 127K), mean output 244 tokens, 1–2 requests in flight. That is long-prompt agentic traffic, not a short-prompt microbenchmark — TTFT at 1K-token inputs is substantially lower.
+
+Together also reports serving the model quantized to fp8 (MLP-only blockwise e4m3, 128×128, with dynamic activations; attention, embeddings and the vision tower stay bf16), chosen after checking quality against a bf16 reference on the same hardware — GPQA-Diamond 83.7 ± 0.9 over 6 runs, against 83.5 on the model card. Precision is not something you select on this endpoint; it is noted because a quantized serving path is worth knowing about when you compare a hosted result to a local bf16 one.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `401` on every request | `TOGETHER_API_KEY` unset, or the key is from a different account | Re-export the key from https://api.together.xyz/settings/api-keys and re-run the `/v1/models` check above |
+| Output repeats or loops | `temperature 0` / greedy decoding | Use the checkpoint defaults (`temperature 0.95`, `top_p 1.0`) |
+| Multi-tool prompts produce one call per turn instead of parallel calls | `<\|eom\|>` passed as a stop token, or a client that flattens `tools` into the prompt | Send `tools` as a top-level request field and leave `stop` unset |
+| Long requests end at 32,768 output tokens | Together caps generation per request | Split the task; the cap guards runaway reasoning loops |
+| `503 Service unavailable` minutes after provisioning a dedicated endpoint | Replica still warming (Together reports ~10–15 min for graph compile and fp8 kernel warmup) | Retry with backoff until the first `200`. Serverless is not affected |
+
+## Support
+
+- Model page: https://www.together.ai/models/muse-glimmer
+- Docs: https://docs.together.ai
+- Pricing: https://www.together.ai/pricing
+- Issues: https://www.together.ai/support
+- Maintainer: Mourya Vangala Srinivasa (msrinivasa@together.ai)


### PR DESCRIPTION
Adds a `hosted/` section for providers that serve Muse Glimmer as an API, starting with Together AI.

Ground truth for the whole page is Together’s published model page, https://www.together.ai/models/muse-glimmer, read 2026-08-11. The partner draft this came from predates that page.

## The model string

`meta-models/Muse-Glimmer-30B` — what Together lists as the endpoint, and what appears in all three of their published examples. Taken verbatim from their page; nothing invented.

## What the official page corrected

| | Draft said | Published page says |
|---|---|---|
| Model name | pre-release name throughout the prose | Muse Glimmer / `meta-models/Muse-Glimmer-30B` |
| Quickstart | `pip install openai` | Together’s own SDK (`together` / `together-ai`), plus curl |
| Modalities | image **and video** inputs verified | text and image in, text out — no video |
| Pricing | absent | $0.35 /1M in ($0.04 cached), $1.50 /1M out |
| Context | 131,072, framed as one replica’s capability | 128K+, and extendable |
| Deployment | dedicated 2×H100 replicas only | serverless **and** dedicated, 99.9% SLA |
| Licence / release | absent | Apache 2.0, released August 10 2026 |

Cross-checked pricing against https://www.together.ai/pricing — both pages agree.

## On the unreachable artifact

The draft linked a serving artifact that returns HTTP 401 anonymously. It appears **nowhere** on the official model page. Conclusion: no reader ever needs it — hosted access is a model string plus an API key against `api.together.xyz`, and nothing in the workflow touches HuggingFace. So the 401 blocks nobody; the page simply should not have pointed at it. Removed rather than renamed — inventing a replacement identifier would have made the page wrong.

The page now links the public model card, https://huggingface.co/meta-models/Muse-Glimmer-30B (HTTP 200), which is the same repo the root README already uses.

## Other removals

- `assets/together-ai-demo.png` was embedded but does not exist in the repo, and the official page offers no equivalent image. Embed removed; the expected behaviour is described in prose instead.
- The `vllm bench serve` repro command is dropped. It could not be verified, it would bill the reader against a paid endpoint, and it passed `TOGETHER_API_KEY` to a tool that reads `OPENAI_API_KEY`.
- Hardware-page scaffolding (Platforms table, driver/CUDA snapshot, a precision table with a `bf16 — Not supported` row) is dropped. You do not select precision on someone else’s API. Together’s fp8 serving detail is kept as an attributed note.

## Structure

`validate.py` globs `platform/*.md` only, so this file is neither validated nor indexed by it, and `platform/` is untouched (`python platform/validate.py` → 0 errors, 0 warnings). The `VENDOR_TEMPLATE` four-section shape exists to compare *hardware* step by step and to feed the generated platform index; neither applies here. The frontmatter is kept, since “every page is attributed and dated” is a repo-wide convention worth honouring.

Together’s measured numbers are kept but attributed to them and dated, never presented as ours.

## Local-first

`hosted/README.md` reconciles the new section in two sentences: the weights are open and run locally, and this folder is for readers who would rather not operate the hardware. It states plainly that this is the one place in the repo requiring an API key, and points back to `inference-server/` and `platform/` for the alternative. **The root README’s local-first principle is unchanged** — the only root edit is one added row in “Pick your path”.

## Verification

- Every external URL in the new files returns 200 (`/v1/chat/completions` → 405 GET-only, `/v1/models` → 401 unauthenticated: both as expected).
- All 7 relative links resolve.
- `python platform/validate.py` → clean.
- Commit message and diff scrubbed for pre-release and competitor names.

## Noted, not changed

The root README’s model table says vision is “a fast-follow”, while Together publishes image input as available today. Out of scope here — flagging for a separate decision.