### PR TITLE
README: vision is supported today, not a fast-follow

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Each recipe follows the same contract so you always know what you're getting:
 | Size | 30B dense decoder. |
 | Suggested GPU | Fits a single 24–32 GB GPU when quantized (Q4/INT4, ~16–17 GB); bf16 needs ~60 GB (an 80 GB card, or sharded across several GPUs). |
 | Context | 131072 tokens (128K). |
-| Modalities | Text and tool calling today. Vision (image, video) is a fast-follow. |
+| Modalities | Text and image in, text out, plus tool calling — all supported today, through a dedicated ~1.8B perception encoder. Server support for image input varies; each [`inference-server/`](inference-server/) page states where it stands. Video is not a supported input: the model card processes it as individual frames and is not explicitly optimized for it. |
 | Tool format | An XML-ish `<atem:function_calls>` block. See [`agentic-fundamentals/`](agentic-fundamentals/). |
 | Chat framing | Channel-scoped `<\|start\|>role<\|message\|>…<\|eot\|>` with a `to=self` reasoning channel. |
 | License | See the [model card](https://huggingface.co/meta-models/Muse-Glimmer-30B) on HuggingFace. |

--- a/inference-server/vllm.md
+++ b/inference-server/vllm.md
@@ -29,7 +29,7 @@ What the image gives you for Muse Glimmer:
 
 Parser names use **underscores** (`muse_glimmer`). vLLM matches them literally, so the hyphenated form fails. `--served-model-name muse-glimmer` is a label you choose and stays hyphenated.
 
-Vision (multimodal) is a fast-follow. Text and tool calling work today.
+Image input is a model capability, not a pending one — the checkpoint ships a perception encoder, and vLLM's own recipe lists this model under both `text` and `multimodal` and budgets memory for that encoder. What this page cannot give you is an attested image request: the official recipe publishes no image example, and nobody has run one against this cookbook. Treat the commands below as text and tool calling. For an image path verified today, see [`llama-cpp.md`](llama-cpp.md).
 
 Full tool calling needs a checkpoint converted with the current HF Muse Glimmer converter, whose tokenizer registers the framing tokens (`<|eom|>`, `<|eot|>`, `<|start|>`, `<|message|>`) as real single tokens. Legacy exports still work for text and NLL, but won't produce clean token-level framing.
 


### PR DESCRIPTION
The root README's model table said vision was **"a fast-follow"**. It isn't — image input is supported today — and the same sentence also promised **video**, which no published path offers. Both are corrected here.

## What changed

**`README.md`** — the Modalities row now states text and image in, text out, plus tool calling, all available today via the dedicated ~1.8B perception encoder. It notes that per-server support varies and points at `inference-server/`, and it states plainly that video is not a supported input.

**`inference-server/vllm.md`** — no longer calls vision a fast-follow. Details below; this one needed judgement rather than a find-and-replace.

## Evidence that image input is available today

| Source | What it says | Checked |
|---|---|---|
| [Model card](https://huggingface.co/meta-models/Muse-Glimmer-30B) | "a dedicated perception encoder… the model accepts interleaved text and images"; tagged `image-text-to-text`; reports MMMU-Pro 74 | live, 2026-08-11 |
| [Together AI](https://www.together.ai/models/muse-glimmer) | Type "Chat, Vision"; **Input modalities: Text, Image**, Output: Text | live, 2026-08-11 |
| `inference-server/llama-cpp.md` | vision projector landed in the same upstream commit as the architecture (`62bf73d25`); `--mmproj mmproj-kquant.gguf` documented and run on Metal | in repo |
| `inference-server/executorch.md` | 8 of the 16 published PTE variants are `text-image`; export takes `--mmproj` and writes `pos_embed.bin` | in repo |
| [GGUF repo](https://huggingface.co/meta-models/Muse-Glimmer-30B-GGUF) | ships `mmproj-kquant.gguf` | live, 2026-08-11 |

## Why video is now stated as unsupported

The model card is explicit: *"The model is not explicitly optimized for video; video input is processed as individual frames."* Together lists image only. Promising video was the bigger error of the two, so the row now says so rather than staying silent.

## The distinction this PR is careful about

**The model supports vision; individual servers vary.** The root README states the model's capability. Per-server pages keep their own status, and the genuine per-path gaps are left exactly as they were:

- `sglang.md` — NVFP4 ships no vision weights (`--language-model-only` required), and the GGUF path is text-only by construction. Both **unchanged and still accurate**.
- `ollama.md` — its pending banner is about tool calling, not vision. Untouched.

## The vLLM call

`vllm.md` said "Vision (multimodal) is a fast-follow." I checked whether that still matched vLLM's own position, and it does not: the [official recipe](https://recipes.vllm.ai/meta-models/Muse-Glimmer-30B) tags this model `["text", "multimodal"]`, describes it as a "vision-language model with a ViT-G/14 perception encoder", and budgets GB10 memory for "the KV cache and the perception encoder". Our own capability table on that page already notes the config resolves `muse_glimmer_vision` automatically.

What is genuinely missing is an *attested image request* — the upstream recipe publishes no image example, and nobody has run one against this cookbook, which is consistent with that page's existing "unverified end to end" banner. So the page now says exactly that, and points to `llama-cpp.md` for a path verified today, instead of implying the model lacks the capability.

## Verification

- `python platform/validate.py` → 0 errors, 0 warnings.
- Every external URL cited above returns HTTP 200; all relative links resolve.
- Grepped `fast-follow`, `fast follow`, `vision`, `multimodal`, `image` across all `*.md` and judged each hit; only the two lines changed here framed vision as pending.
- No video claim added anywhere.
