### PR TITLE
docs: correct the recipe verification claim, refresh the computer-use-web recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A local agent running on your own machine that completes a real multi-step task,
 | Run the model with a single command | [`quickstart/`](quickstart/) |
 | Learn the tool-use loop (chat template, function calling, the agent loop) | [`agentic-fundamentals/`](agentic-fundamentals/) |
 | Ship a flagship agent (structured output, reasoning control, a triage pipeline) | [`recipes/`](recipes/) |
-| Serve Muse Glimmer (vLLM, Ollama, LM Studio, SGLang, llama.cpp) | [`inference-server/`](inference-server/) |
+| Serve Muse Glimmer (vLLM, Ollama, LM Studio, SGLang, llama.cpp, Unsloth, ExecuTorch) | [`inference-server/`](inference-server/) |
 | Deploy on specific partner hardware, and see which precisions it supports | [`platform/`](platform/) |
 | Call a hosted API instead of running the model yourself (needs a provider API key) | [`hosted/`](hosted/) |
 
@@ -31,7 +31,7 @@ Each recipe follows the same contract so you always know what you're getting:
 
 - **Runs end to end, offline**: Any network use is optional and flagged.
 - **Recipe banner up top**: Max VRAM we actually observed, precision, and model server before you run anything. We don't publish numbers for hardware we haven't run on.
-- **bf16 on vLLM**: Every recipe is verified at bf16 and served with vLLM. Quantized builds work; we just don't verify each recipe across every quant scheme.
+- **Precision and server vary by recipe**: Each banner names the one combination that recipe was actually run on — most are bf16 on vLLM, while [`recipes/computer-use-web/`](recipes/computer-use-web/) runs a Q4KM GGUF on llama.cpp. Other combinations generally work; we just don't re-verify every recipe against each one.
 - **Copy-paste first**: One command to run. The explanation comes after.
 - **Ends with "make it yours"**: The extension hook, plus troubleshooting.
 
@@ -56,4 +56,4 @@ Contributions welcome. Every recipe follows the shared template in [`assets/RECI
 
 ## License
 
-Please refere to the [License](LICENSE)
+Please refer to the [License](LICENSE)

--- a/recipes/computer-use-web/README.md
+++ b/recipes/computer-use-web/README.md
@@ -9,7 +9,7 @@ It works the way a person does: look at the screen, decide where to click, click
 | | |
 |---|---|
 | Precision | Quantized GGUF (Q4KM K-quant, ~17 GB on disk) |
-| Model server | llama.cpp, Muse Glimmer build |
+| Model server | llama.cpp (upstream, release `b10353` or newer) |
 | Offline? | Model runs locally; the task itself browses the web |
 | Memory observed | ~25 GB — model + vision projector + 128K KV cache |
 | Requires | [metacua](https://github.com/meta-models/meta-model-cookbook/tree/main/03_use_cases/13_macos_cua) · macOS with Safari |
@@ -21,32 +21,37 @@ It works the way a person does: look at the screen, decide where to click, click
 
 ### 1. Serve Muse Glimmer with vision
 
-Follow [`../../inference-server/llama-cpp.md`](../../inference-server/llama-cpp.md), then:
+Follow [`../../inference-server/llama-cpp.md`](../../inference-server/llama-cpp.md) for the download and the build — you need `muse-glimmer-30B-kquant-17gb.gguf` plus `mmproj-kquant.gguf` for image input, and llama.cpp release [`b10353`](https://github.com/ggml-org/llama.cpp/releases/tag/b10353) or newer. Upstream supports Muse Glimmer, so no fork is needed; `b10344` and older refuse to load these checkpoints with `unknown model architecture: 'muse-glimmer'`. Then:
 
 ```bash
 ./build/bin/llama-server \
   -m ./muse-glimmer/muse-glimmer-30B-kquant-17gb.gguf \
   --mmproj ./muse-glimmer/mmproj-kquant.gguf \
+  -a muse-glimmer \
   -ngl 99 -c 131072 -np 1 \
   --host 127.0.0.1 --port 8080 --api-key muse-glimmer \
   --jinja \
   --chat-template-kwargs '{"reasoning_strength":"high"}'
 ```
 
+- `-a muse-glimmer` is the name the API answers to, and it has to match the `--model muse-glimmer` set in step 4. Without it the alias is the checkpoint path and the request does not match.
 - `-np 1` keeps the whole context in one slot; the agent needs it.
-- `--chat-template-kwargs '{"reasoning_strength":"high"}'` is where reasoning length is set. **metacua's `--effort` flag has no effect here** — llama.cpp does not read the Responses API's `reasoning.effort` field, so the server flag is the only knob. See [Controlling reasoning length](../../inference-server/llama-cpp.md#controlling-reasoning-length).
+- `--jinja` applies the template embedded in the GGUF. It is what wires up tool calling and the correct stop set — `<|end_of_text|>` and `<|eot|>`, never `<|eom|>`.
+- `--chat-template-kwargs '{"reasoning_strength":"high"}'` is where reasoning length is set; the levels are `low`, `medium`, `high` and `xhigh`. **metacua's `--effort` flag has no effect here** — llama.cpp does not read the Responses API's `reasoning.effort` field, so the server flag is the only knob. See [Controlling reasoning length](../../inference-server/llama-cpp.md#controlling-reasoning-length).
 - This recipe wants `high`. A misclick navigates somewhere else and costs several steps to undo, so deliberation is worth paying for — unlike tasks whose environment validates each action for free.
 
 ### 2. Install metacua
 
 ```bash
 git clone https://github.com/meta-models/meta-model-cookbook.git
-cd meta-model-cookbook/03_use_cases/13_macos_cua/python
+cd meta-model-cookbook
+git fetch origin pull/11/head:pr-11 && git switch pr-11
+cd 03_use_cases/13_macos_cua/python
 python3 -m venv .venv && .venv/bin/python -m pip install -U pip
 .venv/bin/pip install -e .
 ```
 
-Use a checkout that includes [meta-model-cookbook#11](https://github.com/meta-models/meta-model-cookbook/pull/11). Before it, the Python backend returned the screenshot inside the tool result, which llama.cpp rejects with `Output of tool call should be 'Input text'` on the second step of every run.
+[meta-model-cookbook#11](https://github.com/meta-models/meta-model-cookbook/pull/11) is still open, which is why the checkout above moves onto it instead of staying on `main`. On `main` the Python backend returns the screenshot inside the tool result, which llama.cpp rejects with `Output of tool call should be 'Input text'` on the second step of every run. Once it merges, clone `main` and drop the fetch/switch line.
 
 ### 3. Grant macOS permissions
 


### PR DESCRIPTION
The root README claimed every recipe is verified at bf16 and served with
vLLM. Both halves are false, and the repo disproves them: the
computer-use-web recipe declares a Q4KM GGUF on llama.cpp in its own
banner and serves with llama-server. The follow-on sentence made it
worse by saying quantized builds are specifically not what recipes are
verified on, when a shipped recipe is verified exactly there. It also
sat two lines under "We don't publish numbers for hardware we haven't
run on", so the front page broke its own contract.

Replaced with what the four banners actually say: each names the one
precision and server that recipe was run on, most are bf16 on vLLM, and
computer-use-web is the Q4KM-on-llama.cpp exception. Checked against all
four banners, not just the three that agreed.

Two smaller README fixes alongside it. The inference-server row listed
five servers and omitted Unsloth and ExecuTorch, both of which have
pages; it now lists all seven, in the order inference-server/README.md
uses. "Please refere to" is now "refer".

The computer-use-web recipe is brought up to current main:

- The banner said "llama.cpp, Muse Glimmer build". Upstream supports
  Muse Glimmer and no fork is needed, so this now reads "llama.cpp
  (upstream, release b10353 or newer)". The Precision row is unchanged
  at Q4KM GGUF and the server is still llama.cpp - that is what was
  actually run, and it is what makes the README fix above correct.
  Nothing here was upgraded to a combination nobody ran.
- Setup step 1 now carries the b10353 version floor, the
  "unknown model architecture: 'muse-glimmer'" failure that b10344 and
  older give, and the two GGUF filenames this recipe needs.
- The serve command was missing -a muse-glimmer while step 4 configures
  metacua with --model muse-glimmer. Without the alias the served name
  is the checkpoint path and the request does not match, so the recipe
  as written could not run. Added, with the reason.
- Documented that --jinja is what wires up the correct stop set,
  <|end_of_text|> and <|eot|>, never <|eom|>, and named the four
  reasoning levels: low, medium, high, xhigh.
- Install step 2 cloned main and then told the reader to "use a checkout
  that includes meta-model-cookbook#11". That PR is still open, so main
  does not contain it and the instruction could not be followed. The
  clone now fetches the PR ref explicitly, and the note says the PR is
  open and what to drop once it merges.

The redundant reasoning-format flag was already dropped from this recipe
in #19, so there was nothing left to remove here.

Verified against the live pages on main and the live metacua sources:
GGUF filenames and the version floor against inference-server/llama-cpp.md;
the metacua subcommands, flags, normalized 0-1000 coordinate default,
40-step default and MODEL_API_KEY precedence against the upstream CLI on
main; the PR ref fetch by actually performing it.

Docs only, no behaviour change.
