### PR TITLE
docs(computer-use-web): serve the dynamic GGUF, drop the numbers that don't transfer

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ A local agent running on your own machine that completes a real multi-step task,
 Each recipe follows the same contract so you always know what you're getting:
 
 - **Runs end to end, offline**: Any network use is optional and flagged.
-- **Recipe banner up top**: Max VRAM we actually observed, precision, and model server before you run anything. We don't publish numbers for hardware we haven't run on.
-- **Precision and server vary by recipe**: Each banner names the one combination that recipe was actually run on — most are bf16 on vLLM, while [`recipes/computer-use-web/`](recipes/computer-use-web/) runs a Q4KM GGUF on llama.cpp. Other combinations generally work; we just don't re-verify every recipe against each one.
+- **Recipe banner up top**: Precision, model server, and the max VRAM we observed, before you run anything. We don't publish numbers for hardware we haven't run on — where a recipe hasn't been measured, its banner says so instead of estimating.
+- **Precision and server vary by recipe**: Most are bf16 on vLLM; [`recipes/computer-use-web/`](recipes/computer-use-web/) is a quantized GGUF on llama.cpp. Other combinations generally work; we just don't re-verify every recipe against each one.
 - **Copy-paste first**: One command to run. The explanation comes after.
 - **Ends with "make it yours"**: The extension hook, plus troubleshooting.
 

--- a/recipes/computer-use-web/README.md
+++ b/recipes/computer-use-web/README.md
@@ -8,11 +8,13 @@ It works the way a person does: look at the screen, decide where to click, click
 
 | | |
 |---|---|
-| Precision | Quantized GGUF (Q4KM K-quant, ~17 GB on disk) |
+| Precision | Quantized GGUF — dynamic K-quant (`muse-glimmer-30B-kquant-dynamic.gguf`, ~20 GB on disk) |
 | Model server | llama.cpp (upstream, release `b10353` or newer) |
 | Offline? | Model runs locally; the task itself browses the web |
-| Memory observed | ~25 GB — model + vision projector + 128K KV cache |
 | Requires | [metacua](https://github.com/meta-models/meta-model-cookbook/tree/main/03_use_cases/13_macos_cua) · macOS with Safari |
+
+> [!NOTE]
+> Status: not verified on this checkpoint. The walkthrough below was worked out on a different GGUF from the same repo. The llama.cpp flags and the metacua setup do not depend on which of the published checkpoints you load, so those carry over — but no measurement from that run does, which is why this banner publishes none. What *is* confirmed: `muse-glimmer-30B-kquant-dynamic.gguf` and `mmproj-kquant.gguf` are published in [`meta-models/Muse-Glimmer-30B-GGUF`](https://huggingface.co/meta-models/Muse-Glimmer-30B-GGUF), and llama.cpp `b10353` or newer loads this architecture. What is *not* confirmed: peak memory on this build, or that the agent loop runs end to end on it. If you complete a run, please say so in an issue so we can upgrade this banner.
 
 > [!CAUTION]
 > `metacua` takes real control of your Mac — it moves the pointer, types, and clicks whatever the model decides, with no confirmation step. Keep the terminal reachable so you can `Ctrl+C`, and don't type in other apps while it runs. Web pages can also prompt-inject the agent, so prefer sites you trust.
@@ -21,11 +23,22 @@ It works the way a person does: look at the screen, decide where to click, click
 
 ### 1. Serve Muse Glimmer with vision
 
-Follow [`../../inference-server/llama-cpp.md`](../../inference-server/llama-cpp.md) for the download and the build — you need `muse-glimmer-30B-kquant-17gb.gguf` plus `mmproj-kquant.gguf` for image input, and llama.cpp release [`b10353`](https://github.com/ggml-org/llama.cpp/releases/tag/b10353) or newer. Upstream supports Muse Glimmer, so no fork is needed; `b10344` and older refuse to load these checkpoints with `unknown model architecture: 'muse-glimmer'`. Then:
+Follow [`../../inference-server/llama-cpp.md`](../../inference-server/llama-cpp.md) for the build — you need llama.cpp release [`b10353`](https://github.com/ggml-org/llama.cpp/releases/tag/b10353) or newer. Upstream supports Muse Glimmer, so no fork is needed; `b10344` and older refuse to load these checkpoints with `unknown model architecture: 'muse-glimmer'`.
+
+That page downloads the smaller text build; this recipe uses the dynamic one, plus the vision projector for image input:
+
+```bash
+pip install -U huggingface_hub
+hf download meta-models/Muse-Glimmer-30B-GGUF --local-dir ./muse-glimmer \
+  --include "muse-glimmer-30B-kquant-dynamic.gguf" \
+  --include "mmproj-kquant.gguf"
+```
+
+Then:
 
 ```bash
 ./build/bin/llama-server \
-  -m ./muse-glimmer/muse-glimmer-30B-kquant-17gb.gguf \
+  -m ./muse-glimmer/muse-glimmer-30B-kquant-dynamic.gguf \
   --mmproj ./muse-glimmer/mmproj-kquant.gguf \
   -a muse-glimmer \
   -ngl 99 -c 131072 -np 1 \


### PR DESCRIPTION
Follow-up to #23, which merged before the correction arrived: **Q4KM is not an officially supported quantization**, so `recipes/computer-use-web/` now serves the dynamic quantized GGUF. Everything else from #23 stays.

### The model file

`muse-glimmer-30B-kquant-17gb.gguf` -> `muse-glimmer-30B-kquant-dynamic.gguf`. Filename and the ~20 GB size are read off `inference-server/llama-cpp.md` on `main`, not estimated.

The setup step said "follow llama-cpp.md for the download", but that page's `hf download` fetches the 17 GB file, so a reader would have ended up with the wrong checkpoint. Replaced with an explicit `hf download` carrying the right `--include`.

### The honesty problem

The banner claimed `Q4KM K-quant, ~17 GB` and `Memory observed | ~25 GB — model + vision projector + 128K KV cache`. Those were real measurements from a real run — on the *other* checkpoint. Nobody has run this recipe on the dynamic build, so none of it transfers.

The memory row is **removed**, not rescaled. Scaling ~25 GB by the disk-size delta and re-labelling the result "observed" would have been a new false claim, so the row is gone and a status note modelled on `inference-server/vllm.md:6` says what is and is not confirmed:

- confirmed: both checkpoints are published in `meta-models/Muse-Glimmer-30B-GGUF`, and llama.cpp `b10353`+ loads the architecture
- not confirmed: peak memory on this build, or that the agent loop runs end to end on it

The flags and the metacua setup do carry over — they don't depend on which of the published checkpoints you load — and the note says so, so the walkthrough is not thrown away.

No timing or throughput observations existed elsewhere in the file; `git grep` for those turned up nothing to remove.

### Front page

`README.md` had two bullets that stopped being true once the memory row went:

- "Max VRAM we actually observed, precision, and model server" — no longer describes every banner
- "Each banner names the one combination that recipe was actually run on ... a Q4KM GGUF on llama.cpp" — names the quant on the front page, and the "actually run on" claim is now false for this recipe

Both are reworded to hold for all four recipes as they stand after this change: three are bf16 on vLLM with an observed VRAM figure, `computer-use-web` is a quantized GGUF on llama.cpp with its unmeasured figure stated as unmeasured rather than estimated. The "other combinations generally work, we don't re-verify each one" point from #23 is kept verbatim.

`recipes/README.md` describes recipes but names no precision, so it needed no change.

### Checks

- `python platform/validate.py` -> 0 errors, 0 warnings
- relative-link sweep over all 110 relative links in the repo -> the only two failures are pre-existing on `edd7712` in `platform/_template/VENDOR_TEMPLATE.md`, whose `../inference-server/...` paths are written for `platform/<vendor>.md` rather than the `_template/` subdirectory. Untouched here.
- `git grep -in "q4km"` -> only `RadixArk/Muse-Glimmer-q4km-gs128-MLX` in `sglang.md`, a published third-party artifact name that is still accurate

### Left alone, worth a look separately

`inference-server/llama-cpp.md:25` still marks the 17 GB build "**use this one**". This PR was scoped to the recipe, but if Q4KM is unsupported as a matter of policy then that default is the next thing to revisit.
