### PR TITLE
inference-server: fix the ExecuTorch download commands

### DIFF
--- a/inference-server/executorch.md
+++ b/inference-server/executorch.md
@@ -31,8 +31,10 @@ pip install -r examples/llm_server/python/requirements.txt
 Exports lower directly from the quantized GGUFs — the same files [`llama-cpp.md`](llama-cpp.md) uses — plus tokenizer metadata from the safetensors repo. Run from the ExecuTorch repository root:
 
 ```bash
-hf download meta-models/Muse-Glimmer-30B-GGUF \
-  --include '*.gguf' --exclude '*[Bb][Ff]16*.gguf' --local-dir assets/quant
+hf download meta-models/Muse-Glimmer-30B-GGUF --local-dir assets/quant \
+  --include 'muse-glimmer-30B-kquant-17gb.gguf' \
+  --include 'dflash-kquant.gguf' \
+  --include 'mmproj-kquant.gguf'
 
 hf download meta-models/Muse-Glimmer-30B \
   tokenizer.json chat_template.jinja config.json processor_config.json \
@@ -42,9 +44,9 @@ hf download meta-models/Muse-Glimmer-30B \
 `chat_template.jinja` must stay beside the tokenizer metadata; the serving path renders prompts and tool definitions with it.
 
 ```bash
-TARGET="$(find assets/quant -name 'muse-glimmer-30B-kquant-17gb.gguf' -print -quit)"
-DRAFT="$(find assets/quant -name 'dflash-kquant.gguf' -print -quit)"
-MMPROJ="$(find assets/quant -name 'mmproj-kquant.gguf' -print -quit)"
+TARGET=assets/quant/muse-glimmer-30B-kquant-17gb.gguf
+DRAFT=assets/quant/dflash-kquant.gguf
+MMPROJ=assets/quant/mmproj-kquant.gguf
 BACKEND=cuda   # mlx on macOS
 ```
 
@@ -106,7 +108,8 @@ Each directory holds `<directory-name>.pte`; `sm80+ptx` variants add `<directory
 EXPORT_DIR=muse-glimmer-k-quant-17G-128K-text-solo-sm80+ptx
 
 hf download meta-models/Muse-Glimmer-30B-ExecuTorch-PTE \
-  --include "$EXPORT_DIR/*" tokenizer.json tokenizer_config.json chat_template.jinja \
+  --include "$EXPORT_DIR/*" \
+  --include tokenizer.json --include tokenizer_config.json --include chat_template.jinja \
   --local-dir exports
 ```
 


### PR DESCRIPTION
Three defects in `inference-server/executorch.md`, all verified with `hf download --dry-run` rather than by reading.

### 1. The prebuilt-export download never fetches the model

`:109` mixed `--include` with positional filenames:

```bash
--include "$EXPORT_DIR/*" tokenizer.json tokenizer_config.json chat_template.jinja
```

`huggingface_hub` warns `Ignoring --include since filenames have being explicitly set` and downloads **3 files, 28.2 MB**. The reader ends up with tokenizer metadata, no `.pte`, and a serve command that fails on a missing path. Giving each pattern its own `--include` yields **5 files, 19.8 GB**.

This is the same trap flagged in the ExecuTorch model card; the cookbook page still had it.

### 2. The GGUF download pulled ~20 GB that is never used

`--include '*.gguf'` fetches all four published builds — **39.4 GB**. The export uses `kquant-17gb`, `dflash-kquant` and `mmproj-kquant`; `kquant-dynamic` (19.7 GB) is downloaded and never referenced. Naming the three files: **19.8 GB**.

### 3. `--exclude '*[Bb][Ff]16*.gguf'` matched nothing

No bf16 GGUF is published — the repo has exactly four files, all K-quant. The flag was inert and implied a bf16 GGUF exists. Removed.

### Follow-on

Naming the files makes their paths deterministic, so the `find ... -print -quit` lookups are replaced with direct paths.

### Verification

| Command | Before | After |
|---|---|---|
| Prebuilt export | 3 files, 28.2 MB (no model) | 5 files, 19.8 GB |
| GGUF assets | 4 files, 39.4 GB | 3 files, 19.8 GB |