### PR TITLE
docs(llama.cpp): correct Linux prebuilt claims, add Ampere arch

### DIFF
--- a/inference-server/llama-cpp.md
+++ b/inference-server/llama-cpp.md
@@ -42,7 +42,10 @@ Muse Glimmer support first shipped in release [`b10353`](https://github.com/ggml
 >
 > `llama-server --version` prints the build number to check against: `version: 10353 (...)` or higher.
 
-The [releases page](https://github.com/ggml-org/llama.cpp/releases) publishes prebuilt binaries for macOS arm64 (Metal), Linux (CPU, CUDA, ROCm, Vulkan, SYCL) and Windows. If you take one, unpack it and skip to [Serve](#serve) — read `./build/bin/` in the commands below as the directory you unpacked.
+The [releases page](https://github.com/ggml-org/llama.cpp/releases) publishes prebuilt binaries for macOS arm64 (Metal), Windows (CPU, CUDA) and Linux (CPU, ROCm, Vulkan, SYCL, OpenVINO). If you take one, unpack it and skip to [Serve](#serve) — read `./build/bin/` in the commands below as the directory you unpacked.
+
+> [!IMPORTANT]
+> There is no prebuilt Linux CUDA binary — CUDA releases are published for Windows only. On Linux with an NVIDIA GPU, install through [llama.app](https://llama.app) or build from source. The Linux tarballs on the releases page are also built against Ubuntu's libstdc++, so on RHEL, CentOS and Fedora-family distros they can fail with `GLIBCXX_3.4.30' not found`.
 
 To build from source instead — `master` is well past the floor:
 
@@ -60,7 +63,7 @@ Pick your backend:
 cmake -B build -DGGML_METAL=ON -DCMAKE_BUILD_TYPE=Release \
   -DLLAMA_BUILD_UI=OFF -DLLAMA_USE_PREBUILT_UI=OFF
 
-# NVIDIA (CUDA >= 12.4; set the arch for your card, 90 = Hopper, 120 = Blackwell)
+# NVIDIA (CUDA >= 12.4; set the arch for your card, 80 = Ampere, 90 = Hopper, 120 = Blackwell)
 cmake -B build -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE=Release -DGGML_NATIVE=OFF \
   -DCMAKE_CUDA_ARCHITECTURES=90 \
   -DLLAMA_BUILD_UI=OFF -DLLAMA_USE_PREBUILT_UI=OFF


### PR DESCRIPTION
The install section makes three claims that don't hold on Linux with an NVIDIA GPU. All reproduced on a RHEL-family host with 2× A100.

 1. The releases page publishes no Linux CUDA binary. Checked both b10353 (the floor this page names) and b10356. Nine       Linux assets each, zero CUDA. CUDA prebuilts are Windows-only (llama-b10356-bin-win-cuda-*).
 
  $ curl -sS https://api.github.com/repos/ggml-org/llama.cpp/releases/tags/b10356 \
       | python3 -c "import json,sys; [print(a['name']) for a in json.load(sys.stdin)['assets'] if 'ubuntu' in a['name']]"
   llama-b10356-bin-ubuntu-arm64.tar.gz
   llama-b10356-bin-ubuntu-openvino-2026.2.1-x64.tar.gz
   llama-b10356-bin-ubuntu-rocm-7.14-x64.tar.gz
   llama-b10356-bin-ubuntu-s390x.tar.gz
   llama-b10356-bin-ubuntu-sycl-fp16-x64.tar.gz
   llama-b10356-bin-ubuntu-sycl-fp32-x64.tar.gz
   llama-b10356-bin-ubuntu-vulkan-arm64.tar.gz
   llama-b10356-bin-ubuntu-vulkan-x64.tar.gz
   llama-b10356-bin-ubuntu-x64.tar.gz
  
 Same result for b10353.
  
  2. The CUDA arch example omits Ampere. The comment lists only 90 = Hopper, 120 = Blackwell. A100 reports compute capability 8.0, i.e. arch 80 — still a very common data-centre GPU.
  
   $ nvidia-smi --query-gpu=name,compute_cap --format=csv
   name, compute_cap
   NVIDIA PG509-210, 8.0
   NVIDIA PG509-210, 8.0
  
   3. The Linux tarballs don't start on RHEL-family distros. Following "unpack it and skip to Serve" with the Vulkan tarball:
  
   $ llama-server --version
   llama-server: /lib64/libstdc++.so.6: version `GLIBCXX_3.4.30' not found
     (required by .../libllama-server-impl.so)
  
   They're built on Ubuntu against a newer libstdc++ than RHEL/CentOS/Fedora ship.
  
   **Changes**: corrects the platform list; adds an [!IMPORTANT] callout noting there's no Linux CUDA prebuilt and pointing Linux NVIDIA users at llama.app or a source build, with the libstdc++ caveat; adds 80 = Ampere.
  
 **Not changed**: llama.app, llama cli and llama serve are upstream's own recommended path and the source-build instructions are correct — this only fixes the claims about what the releases page provides. I couldn't verify whether llama.app itself ships a Linux CUDA build (403 through a corporate proxy from this host), which is why the callout offers it as an option rather than asserting what it installs.