### PR TITLE
quickstart: stop naming the quantization scheme

### DIFF
--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -6,19 +6,19 @@ Every path here runs fully offline after the initial weight download. No API key
 
 ## Pick your server
 
-| Server | Best for | Precision | Guide |
+| Server | Best for | Weights | Guide |
 |---|---|---|---|
-| vLLM | Serving to a team, tool calling | bf16 / fp8 | [jump](#serve-with-vllm) |
+| vLLM | Serving to a team, tool calling | bf16 | [jump](#serve-with-vllm) |
 | HF Transformers | Learning the loop, pure Python | bf16 | [jump](#run-with-hugging-face-transformers) |
-| Ollama | Single command, no build step | Q4_K_M | [jump](#run-with-ollama) |
-| LM Studio | GUI, Apple Silicon (MLX) | Q4 / MLX | [jump](#run-with-lm-studio) |
+| Ollama | Single command, no build step | Quantized GGUF | [jump](#run-with-ollama) |
+| LM Studio | GUI, Apple Silicon (MLX) | Quantized GGUF / MLX | [jump](#run-with-lm-studio) |
 
 > [!NOTE]
 > The dense Muse Glimmer text model is ~29B params.
 > - bf16 lands around 59–60 GB: fits a single 80 GB card, or two cards with tensor parallelism.
-> - Q4_K_M / INT4 lands around 16–17 GB.
+> - The published quantized builds land around 17–20 GB. See [`inference-server/llama-cpp.md`](../inference-server/llama-cpp.md) for the files and their sizes.
 >
-> The agentic recipes in this cookbook target bf16 on vLLM. Quantized paths work, but we don't check each recipe across quant schemes.
+> Each recipe's banner names the weights and server it was run on; those differ by recipe.
 
 ## Serve with vLLM
 
@@ -131,7 +131,7 @@ For tool calling, use the vLLM path above: Ollama's default templates may not em
 > Status: pending LM Studio / MLX quant publish. See [`../inference-server/lm-studio.md`](../inference-server/lm-studio.md).
 
 1. Install LM Studio from [lmstudio.ai](https://lmstudio.ai).
-2. Search the model catalog for Muse Glimmer and download the recommended build (MLX on Apple Silicon, GGUF Q4_K_M elsewhere).
+2. Search the model catalog for Muse Glimmer and download the recommended build (MLX on Apple Silicon, GGUF elsewhere).
 3. Load it and open the Chat tab, or start the Local Server (OpenAI-compatible, `:1234`) to call it from code.
 
 ## Troubleshooting


### PR DESCRIPTION
We publish quantized GGUF builds but not the recipe that produced them, so our own pages should name the artifact rather than characterise the scheme.

### Changes

| Line | Before | After |
|---|---|---|
| Table header | `Precision` | `Weights` |
| vLLM row | `bf16 / fp8` | `bf16` |
| Ollama row | `Q4_K_M` | `Quantized GGUF` |
| LM Studio row | `Q4 / MLX` | `Quantized GGUF / MLX` |
| Size note | `Q4_K_M / INT4 lands around 16–17 GB` | published builds land around 17–20 GB, with a pointer to `llama-cpp.md` |
| LM Studio step 2 | "GGUF Q4_K_M elsewhere" | "GGUF elsewhere" |

`fp8` is dropped because it is not a documented path on `vllm.md` — it appears only in Together's hosted serving detail. The 16–17 GB figure was also wrong for the dynamic build; 17–20 GB covers both.

### Also fixes a false claim

Line 21 read:

> The agentic recipes in this cookbook target bf16 on vLLM. Quantized paths work, but we don't check each recipe across quant schemes.

This is the same claim corrected on the root README in #23 — it is untrue of `recipes/computer-use-web/`, which runs a quantized GGUF on llama.cpp. It now carries the same wording the root README does.

Partner-owned precision tables (`sglang.md`, `platform/intel.md`) are untouched — those are their statements about their own testing.