### PR TITLE
docs(sglang): install without [all], note the cargo prerequisite, verify at t=1

### DIFF
--- a/inference-server/sglang.md
+++ b/inference-server/sglang.md
@@ -11,8 +11,11 @@ pip install --upgrade pip
 pip install uv
 git clone -b muse-glimmer https://github.com/sgl-project/sglang.git
 cd sglang
-uv pip install -e "python[all]"
+uv pip install -e python
 ```
+
+> [!TIP]
+> If the build fails with `cargo is required to discover the Rust extension modules`, prefix it with `SGLANG_BUILD_RUST_EXTS=none` — the Rust extensions are not needed to serve.
 
 > [!WARNING]
 > `uv pip install sglang` — the plain released package — does **not** work. [PR #34262](https://github.com/sgl-project/sglang/pull/34262) is still open, so no PyPI release contains the `muse-glimmer` architecture and the server cannot load these checkpoints. Build the branch above, or take the Docker image below. SGLang's own page carries the same warning.
@@ -202,7 +205,7 @@ curl -s http://localhost:30000/v1/chat/completions \
          "parameters":{"type":"object","properties":{
            "city":{"type":"string"},"units":{"type":"string","enum":["celsius","fahrenheit"]}},
            "required":["city"]}}}],
-       "tool_choice":"auto","temperature":0}'
+       "tool_choice":"auto","temperature":1}'
 ```
 
 A working parser returns a `tool_calls` array with `get_weather(city="Paris", units="celsius")` and the thinking under `reasoning_content`. Treat tool calling as unverified until that is confirmed here.

--- a/inference-server/sglang.md
+++ b/inference-server/sglang.md
@@ -4,21 +4,18 @@ Serve Muse Glimmer with [SGLang](https://docs.sglang.io) for high-throughput inf
 
 ## Install
 
-Muse Glimmer support lives on the `muse-glimmer` branch ([PR #34262](https://github.com/sgl-project/sglang/pull/34262)) rather than in a released version, so install from source:
+Muse Glimmer support is merged into `main` ([PR #34262](https://github.com/sgl-project/sglang/pull/34262), merged 2026-08-11) but is not in a released version yet, so install from source:
 
 ```bash
 pip install --upgrade pip
 pip install uv
-git clone -b muse-glimmer https://github.com/sgl-project/sglang.git
+git clone https://github.com/sgl-project/sglang.git
 cd sglang
 uv pip install -e python
 ```
 
-> [!TIP]
-> If the build fails with `cargo is required to discover the Rust extension modules`, prefix it with `SGLANG_BUILD_RUST_EXTS=none` — the Rust extensions are not needed to serve.
-
 > [!WARNING]
-> `uv pip install sglang` — the plain released package — does **not** work. [PR #34262](https://github.com/sgl-project/sglang/pull/34262) is still open, so no PyPI release contains the `muse-glimmer` architecture and the server cannot load these checkpoints. Build the branch above, or take the Docker image below. SGLang's own page carries the same warning.
+> `uv pip install sglang` — the plain released package — does **not** work yet. [PR #34262](https://github.com/sgl-project/sglang/pull/34262) merged on 2026-08-11, but the newest PyPI release (0.5.17, 2026-08-08) predates it, so no release contains the `muse-glimmer` architecture and the server cannot load these checkpoints. Build from source above, or take the Docker image below. Once a release ships with the merge in it, this should stop being necessary.
 
 A prebuilt image is the alternative:
 
@@ -79,7 +76,7 @@ sglang serve \
   --host 0.0.0.0 --port 30000
 ```
 
-`python -m sglang.launch_server` with the same flags is the equivalent long form; both entrypoints exist on the branch.
+`python -m sglang.launch_server` with the same flags is the equivalent long form; both entrypoints exist on `main`.
 
 ### GGUF Q4_K_M — 32 GB cards
 
@@ -189,10 +186,10 @@ Three MLX artifacts are drop-in `--model-path` swaps: `q4km-gs128` carries the s
 
 ## Verify tool calling
 
-Not verified here. SGLang does ship the parser — `--tool-call-parser muse` resolves to `MuseGlimmerDetector`, and the official page documents tool calling as supported and passes the flag in every published command — but it exists only on the `muse-glimmer` branch, not in `main` or any release, and no tool-calling round has been run against it for this cookbook.
+Not verified here. SGLang does ship the parser — `--tool-call-parser muse` resolves to `MuseGlimmerDetector`, and the official page documents tool calling as supported and passes the flag in every published command — but it landed in `main` only on 2026-08-11 and is not in any release yet, and no tool-calling round has been run against it for this cookbook.
 
 > [!NOTE]
-> SGLang's page says the `muse` reasoning and tool-call parsers are "enabled by default". On the branch as it stands, `tool_call_parser` defaults to `None` in `server_args.py` and there is no Muse Glimmer rule in the chat-template auto-detection table. Pass both flags explicitly, as every command on SGLang's own page does.
+> SGLang's page says the `muse` reasoning and tool-call parsers are "enabled by default". On `main` as it stands, `tool_call_parser` defaults to `None` in `server_args.py` and there is no Muse Glimmer rule in the chat-template auto-detection table. Pass both flags explicitly, as every command on SGLang's own page does.
 
 Once a server is up, this is the check:
 


### PR DESCRIPTION
Corrections to `inference-server/sglang.md`, found while running the SGLang Muse
Glimmer path end to end. Rebased on top of #30.

Verified on a fresh clone of `main` @ `687967c70d` in a clean Python 3.12 env with
uv 0.12.3, serving `meta-models/Muse-Glimmer-30B` (BF16) on one 80GB card.

## 1. The documented install command is broken today

[PR #34262](https://github.com/sgl-project/sglang/pull/34262) merged into `main` on
2026-08-11 and the `muse-glimmer` branch was deleted with it. The guide's first code
block still says:

```bash
git clone -b muse-glimmer https://github.com/sgl-project/sglang.git
```

which now fails outright:

```
fatal: couldn't find remote ref muse-glimmer
```

Muse Glimmer support is in `main`, so this clones `main` instead. Everything else in
this section that assumed the branch still exists is corrected with it:

- "support lives on the `muse-glimmer` branch ... rather than in a released version"
  → merged into `main`, still unreleased
- the `uv pip install sglang` warning said "PR #34262 is still open, so no PyPI
  release contains the architecture". The conclusion still holds but the reasoning
  is stale: the PR merged, and the newest PyPI release (0.5.17, uploaded 2026-08-08)
  simply predates it. Reworded, with a note that this stops applying once a release
  ships with the merge in it.
- "both entrypoints exist on the branch" → on `main`. Also confirmed `sglang serve`
  works, not just `python -m sglang.launch_server`.
- The **Verify tool calling** section said the parser "exists only on the
  `muse-glimmer` branch, not in `main` or any release" — now the reverse of the
  truth. Corrected to: landed in `main` on 2026-08-11, not in any release yet. Its
  status as unverified-in-this-cookbook is unchanged.

## 2. Install without `[all]`

`[all]` resolves to `diffusion + http2 + tracing`. Serving uses none of them, and it
pulls `diffusers`, `opencv-python-headless`, `moviepy`, `scikit-image`, `imageio`,
`imageio-ffmpeg`, `av`, `trimesh`, `xatlas`, `nvidia-modelopt`, `st_attn`, `vsa`,
plus `opentelemetry-*` and `granian`.

After `uv pip install -e python` on a fresh env:

```
sglang 0.5.18.dev419+g687967c70
muse detector: OK
  diffusers: absent
  cv2: absent
  opentelemetry: absent
  PIL: present
```

That env then served all three request types:

| Request | Result |
|---|---|
| Text | `hello from main` |
| Tool call (the curl in this guide, at t=1) | `finish_reason='tool_calls'`, `{"city": "Paris", "units": "celsius"}`, `reasoning_content` present |
| Image input | `The shape is a red triangle.` |

Image requests matter here because BF16 is the multimodal checkpoint — worth being
explicit that dropping `[all]` does **not** cost vision. The diffusion extra is for
image *generation*; the vision dependency (`PIL`) is a base dependency either way.

## 3. Verify at `temperature: 1`

Greedy decoding skips the sampling kernels, which are JIT-compiled on first use. A
server that passes the `t=0` smoke test can therefore still fail on the first real
`t>0` request, and it surfaces as a scheduler crash rather than an HTTP error.

In fairness this is more likely on a misconfigured toolchain than on a supported
setup — the case that prompted it was a local nvcc/CUDA mismatch. But moving the
documented check to `t=1` costs nothing and exercises a path `t=0` never touches.
Ran it 5x; the expected output described in the line below the curl holds every
time, so no surrounding text needed changing:

```
finish_reason='tool_calls'  args={"city": "Paris", "units": "celsius"}  reasoning_content=yes
```

## Dropped from an earlier revision of this PR

An earlier commit added a tip about `cargo` being required for the build. That was
wrong — the failure was a local `PATH` issue on my machine, not a documentation gap.
With cargo on `PATH` the documented command builds the Rust extensions and succeeds.
Removed in the second commit.

## Deliberately not included

- **Tool calling is still marked unverified.** It passes here, but on hardware
  outside SGLang's published matrix, so that claim is left alone.
- **Tensor-parallelism wording unchanged.** TP=2 worked (KV pool 230k → 1.78M tokens
  across two cards), also off-matrix.
- **Hardware-specific serve workarounds excluded.** My box needed a few extra flags
  to serve at all; they are sm80-specific and may not reproduce on the hardware
  SGLang lists, so they are not in this PR.
