### PR TITLE
docs: sync remaining GGUF filenames to the HF repo

### DIFF
--- a/inference-server/sglang.md
+++ b/inference-server/sglang.md
@@ -84,7 +84,7 @@ This is the one combination SGLang publishes for a 32 GB card. `--model-path` po
 
 ```bash
 sglang serve \
-  --model-path meta-models/Muse-Glimmer-30B-GGUF/muse-glimmer-30B-kquant-17gb.gguf \
+  --model-path meta-models/Muse-Glimmer-30B-GGUF/Muse-Glimmer-30B-KQuant-17GB-Q4_K_M.gguf \
   --served-model-name muse-glimmer \
   --reasoning-parser muse \
   --tool-call-parser muse \
@@ -159,7 +159,7 @@ Two target-specific additions, both called out by SGLang:
 - **GGUF target** also needs `--speculative-draft-load-format auto`. Without it the draft inherits the `gguf` load format from the target and the loader rejects the draft directory.
 - **NVFP4 target** also takes `--speculative-draft-model-quantization fp8`.
 
-There is also a **GGUF draft**, `dflash-kquant.gguf`, shipped in the GGUF repo and verified by SGLang on B300. It has a silent failure mode worth knowing about: pass `--speculative-draft-model-quantization gguf` explicitly, or draft quantization resolves before the target's lazy `gguf` load format and the draft is built unquantized from random init. Nothing errors — the draft loads, speculation runs, and the accept length simply sits at 1.0 with no speedup. On every platform except B300 the verified draft is the native `meta-models/Muse-Glimmer-30B-assistant` export, which needs none of this.
+There is also a **GGUF draft**, `dflash-Muse-Glimmer-30B-Q4_K_M.gguf`, shipped in the GGUF repo and verified by SGLang on B300. It has a silent failure mode worth knowing about: pass `--speculative-draft-model-quantization gguf` explicitly, or draft quantization resolves before the target's lazy `gguf` load format and the draft is built unquantized from random init. Nothing errors — the draft loads, speculation runs, and the accept length simply sits at 1.0 with no speedup. On every platform except B300 the verified draft is the native `meta-models/Muse-Glimmer-30B-assistant` export, which needs none of this.
 
 DFlash is not available on the MLX backend.
 

--- a/recipes/computer-use-web/README.md
+++ b/recipes/computer-use-web/README.md
@@ -8,13 +8,13 @@ It works the way a person does: look at the screen, decide where to click, click
 
 | | |
 |---|---|
-| Precision | Quantized GGUF — dynamic K-quant (`muse-glimmer-30B-kquant-dynamic.gguf`, ~20 GB on disk) |
+| Precision | Quantized GGUF — dynamic K-quant (`Muse-Glimmer-30B-KQuant-Dynamic-Q4_K_XL.gguf`, ~20 GB on disk) |
 | Model server | llama.cpp (upstream, release `b10353` or newer) |
 | Offline? | Model runs locally; the task itself browses the web |
 | Requires | [metacua](https://github.com/meta-models/meta-model-cookbook/tree/main/03_use_cases/13_macos_cua) · macOS with Safari |
 
 > [!NOTE]
-> Status: not verified on this checkpoint. The walkthrough below was worked out on a different GGUF from the same repo. The llama.cpp flags and the metacua setup do not depend on which of the published checkpoints you load, so those carry over — but no measurement from that run does, which is why this banner publishes none. What *is* confirmed: `muse-glimmer-30B-kquant-dynamic.gguf` and `mmproj-kquant.gguf` are published in [`meta-models/Muse-Glimmer-30B-GGUF`](https://huggingface.co/meta-models/Muse-Glimmer-30B-GGUF), and llama.cpp `b10353` or newer loads this architecture. What is *not* confirmed: peak memory on this build, or that the agent loop runs end to end on it. If you complete a run, please say so in an issue so we can upgrade this banner.
+> Status: not verified on this checkpoint. The walkthrough below was worked out on a different GGUF from the same repo. The llama.cpp flags and the metacua setup do not depend on which of the published checkpoints you load, so those carry over — but no measurement from that run does, which is why this banner publishes none. What *is* confirmed: `Muse-Glimmer-30B-KQuant-Dynamic-Q4_K_XL.gguf` and `mmproj-Muse-Glimmer-30B-Q4_K_M.gguf` are published in [`meta-models/Muse-Glimmer-30B-GGUF`](https://huggingface.co/meta-models/Muse-Glimmer-30B-GGUF), and llama.cpp `b10353` or newer loads this architecture. What is *not* confirmed: peak memory on this build, or that the agent loop runs end to end on it. If you complete a run, please say so in an issue so we can upgrade this banner.
 
 > [!CAUTION]
 > `metacua` takes real control of your Mac — it moves the pointer, types, and clicks whatever the model decides, with no confirmation step. Keep the terminal reachable so you can `Ctrl+C`, and don't type in other apps while it runs. Web pages can also prompt-inject the agent, so prefer sites you trust.


### PR DESCRIPTION
The GGUF files in meta-models/Muse-Glimmer-30B-GGUF were renamed to carry an explicit quant suffix. executorch.md was updated in #35; llama-cpp.md now resolves by quant tag rather than by filename, so it needs no change. 

These two pages still referenced the old filenames verbatim, so the commands as written no longer resolve:

  muse-glimmer-30B-kquant-17gb.gguf    -> Muse-Glimmer-30B-KQuant-17GB-Q4_K_M.gguf
  muse-glimmer-30B-kquant-dynamic.gguf -> Muse-Glimmer-30B-KQuant-Dynamic-Q4_K_XL.gguf
  mmproj-kquant.gguf                   -> mmproj-Muse-Glimmer-30B-Q4_K_M.gguf
  dflash-kquant.gguf                   -> dflash-Muse-Glimmer-30B-Q4_K_M.gguf

Filename references only. The bare quant tags in llama-cpp.md (`-hf ...GGUF:kquant-17gb`) are deliberately left alone: llama.cpp matches them case-insensitively as a substring, so they still resolve against the new names.